### PR TITLE
Fix printing localized text

### DIFF
--- a/src/vswhere/Program.cpp
+++ b/src/vswhere/Program.cpp
@@ -12,6 +12,8 @@ void WriteLogo(_In_ const CommandArgs& args, _In_ wostream& out);
 
 int wmain(_In_ int argc, _In_ LPCWSTR argv[])
 {
+    _setmode(_fileno(stdout), _O_U16TEXT);
+
     CommandArgs args;
     wostream& out = wcout;
 

--- a/src/vswhere/stdafx.h
+++ b/src/vswhere/stdafx.h
@@ -11,6 +11,8 @@
 
 // Windows headers
 #include <windows.h>
+#include <io.h>
+#include <fcntl.h>
 
 // STL headers
 #include <iomanip>


### PR DESCRIPTION
vswhere print for me:
```
Visual Studio Locator, version 1.0.18-beta-g3511d0cf18
Copyright (C) Microsoft Corporation. All rights reserved.

instanceId: 7a933444
installDate: 17.11.2016
installationName: VisualStudio/15.0.0-RC.3+26127.0
installationPath: D:\Program Files (x86)\Microsoft Visual Studio\2017\Community
installationVersion: 15.0.26127.0
displayName:
```

Somehow after trying to print `displayName: L"Версия-кандидат Visual Studio Community 2017"` `wcout` can't print anything more.