### PR TITLE
Change output encoding for Pester tests

### DIFF
--- a/docker/Tests/vswhere.tests.ps1
+++ b/docker/Tests/vswhere.tests.ps1
@@ -3,6 +3,8 @@
 
 Describe 'vswhere' {
     BeforeEach {
+        [Console]::OutputEncoding = [System.Text.Encoding]::Unicode
+        
         # Make sure localized values are returned consistently across machines.
         $enu = [System.Globalization.CultureInfo]::GetCultureInfo('en-US')
 


### PR DESCRIPTION
Sort of fixes issue #14. PowerShell defaults to the Windows ANSI codepage for console output, so make sure it's set to Unicode prior to tests.