### PR TITLE
Write Unicode to console but native CP to file

### DIFF
--- a/docker/Tests/vswhere.tests.ps1
+++ b/docker/Tests/vswhere.tests.ps1
@@ -3,8 +3,6 @@
 
 Describe 'vswhere' {
     BeforeEach {
-        [Console]::OutputEncoding = [System.Text.Encoding]::Unicode
-        
         # Make sure localized values are returned consistently across machines.
         $enu = [System.Globalization.CultureInfo]::GetCultureInfo('en-US')
 

--- a/src/vswhere.lib/CommandArgs.cpp
+++ b/src/vswhere.lib/CommandArgs.cpp
@@ -119,18 +119,19 @@ void CommandArgs::Parse(_In_ vector<CommandParser::Token> args)
     }
 }
 
-void CommandArgs::Usage(_In_ std::wostream& out) const
+void CommandArgs::Usage(_In_ Console& console) const
 {
     auto pos = m_path.find_last_of(L"\\");
     auto path = ++pos != wstring::npos ? m_path.substr(pos) : m_path;
-    out << ResourceManager::FormatString(IDS_USAGE, path.c_str()) << endl;
+
+    console.WriteLine(ResourceManager::FormatString(IDS_USAGE, path.c_str()));
 
     for (const auto& formatter : Formatter::Formatters)
     {
         UINT nID;
 
         tie(nID, ignore) = formatter.second;
-        out << ResourceManager::FormatString(nID, formatter.first.c_str()) << endl;
+        console.WriteLine(ResourceManager::FormatString(nID, formatter.first.c_str()));
     }
 }
 

--- a/src/vswhere.lib/CommandArgs.h
+++ b/src/vswhere.lib/CommandArgs.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+class Console;
+
 class CommandArgs
 {
 public:
@@ -93,7 +95,7 @@ public:
 
     void Parse(_In_ LPCWSTR wszCommandLine);
     void Parse(_In_ int argc, _In_ LPCWSTR argv[]);
-    void Usage(_In_ std::wostream& out) const;
+    void Usage(_In_ Console& console) const;
 
 private:
     static const std::vector<std::wstring> s_Products;

--- a/src/vswhere.lib/Console.cpp
+++ b/src/vswhere.lib/Console.cpp
@@ -1,0 +1,74 @@
+// <copyright file="Console.h" company="Microsoft Corporation">
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+// </copyright>
+
+#include "stdafx.h"
+
+using namespace std;
+
+void Console::Initialize() noexcept
+{
+    if (IsConsole(stdout))
+    {
+        ::_setmode(_fileno(stdout), _O_WTEXT);
+    }
+    else
+    {
+        char sz[10];
+        ::sprintf_s(sz, ".%d", ::GetConsoleCP());
+
+        ::setlocale(LC_CTYPE, sz);
+    }
+}
+
+void Console::Write(_In_ const std::wstring& value)
+{
+    Write(value.c_str(), NULL);
+}
+
+void Console::Write(_In_ LPCWSTR wzFormat, ...)
+{
+    va_list args;
+
+    va_start(args, wzFormat);
+    Write(wzFormat, args);
+    va_end(args);
+}
+
+void Console::WriteLine()
+{
+    Write(L"\n", NULL);
+}
+
+void Console::WriteLine(_In_ const std::wstring& value)
+{
+    Write(L"%ls\n", value.c_str());
+}
+
+void __cdecl Console::Write(_In_ LPCWSTR wzFormat, va_list args)
+{
+    ::vwprintf_s(wzFormat, args);
+}
+
+bool Console::IsConsole(_In_ FILE* f) const noexcept
+{
+    auto fno = ::_fileno(f);
+    auto hFile = (HANDLE)::_get_osfhandle(fno);
+    auto dwType = ::GetFileType(hFile);
+
+    dwType &= ~FILE_TYPE_REMOTE;
+
+    if (FILE_TYPE_CHAR != dwType)
+    {
+        return false;
+    }
+
+    DWORD dwMode;
+    if (!::GetConsoleMode(hFile, &dwMode))
+    {
+        return false;
+    }
+
+    return true;
+}

--- a/src/vswhere.lib/Console.h
+++ b/src/vswhere.lib/Console.h
@@ -1,0 +1,35 @@
+// <copyright file="Console.h" company="Microsoft Corporation">
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+// </copyright>
+
+#pragma once
+
+class Console
+{
+public:
+    Console(_In_ const CommandArgs& args) :
+        m_args(args)
+    {
+    }
+
+    Console(_In_ const Console& obj) :
+        m_args(obj.m_args)
+    {
+    }
+
+    virtual void Initialize() noexcept;
+
+    void Write(_In_ const std::wstring& value);
+    void Write(_In_ LPCWSTR wzFormat, ...);
+    void WriteLine();
+    void WriteLine(_In_ const std::wstring& value);
+
+protected:
+    virtual void __cdecl Write(_In_ LPCWSTR wzFormat, va_list args);
+
+private:
+    bool IsConsole(_In_ FILE* f) const noexcept;
+
+    const CommandArgs& m_args;
+};

--- a/src/vswhere.lib/Formatter.cpp
+++ b/src/vswhere.lib/Formatter.cpp
@@ -45,29 +45,29 @@ std::unique_ptr<Formatter> Formatter::Create(const std::wstring& type)
     throw win32_error(ERROR_NOT_SUPPORTED);
 }
 
-void Formatter::Write(_In_ const CommandArgs& args, _In_ std::wostream& out, _In_ ISetupInstance* pInstance)
+void Formatter::Write(_In_ const CommandArgs& args, _In_ Console& console, _In_ ISetupInstance* pInstance)
 {
-    StartDocument(out);
-    StartArray(out);
+    StartDocument(console);
+    StartArray(console);
 
-    WriteInternal(args, out, pInstance);
+    WriteInternal(args, console, pInstance);
 
-    EndArray(out);
-    EndDocument(out);
+    EndArray(console);
+    EndDocument(console);
 }
 
-void Formatter::Write(_In_ const CommandArgs& args, _In_ std::wostream& out, _In_ std::vector<ISetupInstancePtr> instances)
+void Formatter::Write(_In_ const CommandArgs& args, _In_ Console& console, _In_ std::vector<ISetupInstancePtr> instances)
 {
-    StartDocument(out);
-    StartArray(out);
+    StartDocument(console);
+    StartArray(console);
 
     for (const auto& instance : instances)
     {
-        WriteInternal(args, out, instance);
+        WriteInternal(args, console, instance);
     }
 
-    EndArray(out);
-    EndDocument(out);
+    EndArray(console);
+    EndDocument(console);
 }
 
 wstring Formatter::FormatDateISO8601(_In_ const FILETIME& value)
@@ -133,11 +133,11 @@ wstring Formatter::FormatDate(_In_ const FILETIME& value)
     return date + L" " + time;
 }
 
-void Formatter::WriteInternal(_In_ const CommandArgs& args, _In_ std::wostream& out, _In_ ISetupInstance* pInstance)
+void Formatter::WriteInternal(_In_ const CommandArgs& args, _In_ Console& console, _In_ ISetupInstance* pInstance)
 {
     _ASSERTE(pInstance);
 
-    StartObject(out);
+    StartObject(console);
 
     const auto& specified = args.get_Property();
     bstr_t bstrValue;
@@ -153,29 +153,29 @@ void Formatter::WriteInternal(_In_ const CommandArgs& args, _In_ std::wostream& 
             if (SUCCEEDED(hr))
             {
                 wstring value = bstrValue;
-                WriteProperty(out, property.first, value);
+                WriteProperty(console, property.first, value);
             }
         }
     }
 
     if (specified.empty() || !found)
     {
-        WriteProperties(args, out, pInstance);
+        WriteProperties(args, console, pInstance);
     }
 
-    EndObject(out);
+    EndObject(console);
 }
 
-void Formatter::WriteProperty(_In_ std::wostream& out, _In_ const wstring& name, _In_ const variant_t& value)
+void Formatter::WriteProperty(_In_ Console& console, _In_ const wstring& name, _In_ const variant_t& value)
 {
     switch (value.vt)
     {
     case VT_BOOL:
-        WriteProperty(out, name, VARIANT_TRUE == value.boolVal);
+        WriteProperty(console, name, VARIANT_TRUE == value.boolVal);
         break;
 
     case VT_BSTR:
-        WriteProperty(out, name, wstring(value.bstrVal));
+        WriteProperty(console, name, wstring(value.bstrVal));
         break;
 
     case VT_I1:
@@ -185,12 +185,12 @@ void Formatter::WriteProperty(_In_ std::wostream& out, _In_ const wstring& name,
     case VT_UI1:
     case VT_UI2:
     case VT_UI4:
-        WriteProperty(out, name, value.llVal);
+        WriteProperty(console, name, value.llVal);
         break;
     }
 }
 
-void Formatter::WriteProperties(_In_ const CommandArgs& args, _In_ std::wostream& out, _In_ ISetupInstance* pInstance)
+void Formatter::WriteProperties(_In_ const CommandArgs& args, _In_ Console& console, _In_ ISetupInstance* pInstance)
 {
     _ASSERTE(pInstance);
 
@@ -230,7 +230,7 @@ void Formatter::WriteProperties(_In_ const CommandArgs& args, _In_ std::wostream
                 hr = store->GetValue(bstrName, vtValue.GetAddress());
                 if (SUCCEEDED(hr))
                 {
-                    WriteProperty(out, name, vtValue);
+                    WriteProperty(console, name, vtValue);
                 }
             }
         }

--- a/src/vswhere.lib/Formatter.h
+++ b/src/vswhere.lib/Formatter.h
@@ -19,8 +19,8 @@ public:
     {
     }
 
-    void Write(_In_ const CommandArgs& args, _In_ std::wostream& out, _In_ ISetupInstance* pInstance);
-    void Write(_In_ const CommandArgs& args, _In_ std::wostream& out, _In_ std::vector<ISetupInstancePtr> instances);
+    void Write(_In_ const CommandArgs& args, _In_ Console& console, _In_ ISetupInstance* pInstance);
+    void Write(_In_ const CommandArgs& args, _In_ Console& console, _In_ std::vector<ISetupInstancePtr> instances);
 
     virtual bool ShowLogo() const
     {
@@ -35,22 +35,22 @@ protected:
 
     static std::wstring FormatDateISO8601(_In_ const FILETIME& value);
 
-    virtual void StartDocument(_In_ std::wostream& out) {}
-    virtual void StartArray(_In_ std::wostream& out) {}
-    virtual void StartObject(_In_ std::wostream& out) {}
-    virtual void WriteProperty(_In_ std::wostream& out, _In_ const std::wstring& name, _In_ const std::wstring& value) {}
-    virtual void EndObject(_In_ std::wostream& out) {}
-    virtual void EndArray(_In_ std::wostream& out) {}
-    virtual void EndDocument(_In_ std::wostream& out) {}
+    virtual void StartDocument(_In_ Console& console) {}
+    virtual void StartArray(_In_ Console& console) {}
+    virtual void StartObject(_In_ Console& console) {}
+    virtual void WriteProperty(_In_ Console& console, _In_ const std::wstring& name, _In_ const std::wstring& value) {}
+    virtual void EndObject(_In_ Console& console) {}
+    virtual void EndArray(_In_ Console& console) {}
+    virtual void EndDocument(_In_ Console& console) {}
 
-    virtual void WriteProperty(_In_ std::wostream& out, _In_ const std::wstring& name, _In_ bool value)
+    virtual void WriteProperty(_In_ Console& console, _In_ const std::wstring& name, _In_ bool value)
     {
-        WriteProperty(out, name, std::to_wstring(value));
+        WriteProperty(console, name, std::to_wstring(value));
     }
 
-    virtual void WriteProperty(_In_ std::wostream& out, _In_ const std::wstring& name, _In_ long long value)
+    virtual void WriteProperty(_In_ Console& console, _In_ const std::wstring& name, _In_ long long value)
     {
-        WriteProperty(out, name, std::to_wstring(value));
+        WriteProperty(console, name, std::to_wstring(value));
     }
 
     virtual std::wstring FormatDate(_In_ const FILETIME& value);
@@ -68,9 +68,9 @@ private:
     HRESULT GetDisplayName(_In_ ISetupInstance* pInstance, _Out_ BSTR* pbstrDisplayName);
     HRESULT GetDescription(_In_ ISetupInstance* pInstance, _Out_ BSTR* pbstrDescription);
 
-    void WriteInternal(_In_ const CommandArgs& args, _In_ std::wostream& out, _In_ ISetupInstance* pInstance);
-    void WriteProperty(_In_ std::wostream& out, _In_ const std::wstring& name, _In_ const variant_t& value);
-    void WriteProperties(_In_ const CommandArgs& args, _In_ std::wostream& out, _In_ ISetupInstance* pInstance);
+    void WriteInternal(_In_ const CommandArgs& args, _In_ Console& console, _In_ ISetupInstance* pInstance);
+    void WriteProperty(_In_ Console& console, _In_ const std::wstring& name, _In_ const variant_t& value);
+    void WriteProperties(_In_ const CommandArgs& args, _In_ Console& console, _In_ ISetupInstance* pInstance);
 
     PropertyArray m_properties;
 };

--- a/src/vswhere.lib/JsonFormatter.cpp
+++ b/src/vswhere.lib/JsonFormatter.cpp
@@ -7,91 +7,91 @@
 
 using namespace std;
 
-void JsonFormatter::StartArray(_In_ wostream& out)
+void JsonFormatter::StartArray(_In_ Console& console)
 {
     m_arrayStart = true;
 
-    out << m_padding << L"[";
+    console.Write(L"%ls[", m_padding.c_str());
     Push();
 }
 
-void JsonFormatter::StartObject(_In_ wostream& out)
+void JsonFormatter::StartObject(_In_ Console& console)
 {
     m_objectStart = true;
 
     if (m_arrayStart)
     {
-        out << endl;
+        console.WriteLine();
     }
     else
     {
-        out << L"," << endl;
+        console.Write(L",\n");
     }
 
-    out << m_padding << L"{" << endl;
+    console.Write(L"%ls{\n", m_padding.c_str());
     Push();
 
     m_arrayStart = false;
 }
 
-void JsonFormatter::WriteProperty(_In_ wostream& out, _In_ const wstring& name, _In_ const wstring& value)
+void JsonFormatter::WriteProperty(_In_ Console& console, _In_ const wstring& name, _In_ const wstring& value)
 {
     if (!m_objectStart)
     {
-        out << L"," << endl;
+        console.Write(L",\n");
     }
 
     auto escaped = replace_all(value, L"\\", L"\\\\");
-    out << m_padding << L"\"" << name << L"\": \"" << escaped << L"\"";
+    console.Write(L"%ls\"%ls\": \"%ls\"", m_padding.c_str(), name.c_str(), escaped.c_str());
 
     m_objectStart = false;
 }
 
-void JsonFormatter::WriteProperty(_In_ wostream& out, _In_ const wstring& name, _In_ bool value)
+void JsonFormatter::WriteProperty(_In_ Console& console, _In_ const wstring& name, _In_ bool value)
 {
     if (!m_objectStart)
     {
-        out << L"," << endl;
+        console.Write(L",\n");
     }
 
-    out << m_padding << L"\"" << name << L"\": " << (value ? L"true" : L"false");
+    console.Write(L"%ls\"%ls\": %ls", m_padding.c_str(), name.c_str(), (value ? L"true" : L"false"));
 
     m_objectStart = false;
 }
 
-void JsonFormatter::WriteProperty(_In_ wostream& out, _In_ const wstring& name, _In_ long long value)
+void JsonFormatter::WriteProperty(_In_ Console& console, _In_ const wstring& name, _In_ long long value)
 {
     if (!m_objectStart)
     {
-        out << L"," << endl;
+        console.Write(L",\n");
     }
 
-    out << m_padding << L"\"" << name << L"\": " << value;
+    console.Write(L"%ls\"%ls\": %d", m_padding.c_str(), name.c_str(), value);
 
     m_objectStart = false;
 }
 
-void JsonFormatter::EndObject(_In_ wostream& out)
+void JsonFormatter::EndObject(_In_ Console& console)
 {
     Pop();
-    out << endl << m_padding << L"}";
+    console.Write(L"\n%ls}", m_padding.c_str());
 }
 
-void JsonFormatter::EndArray(_In_ wostream& out)
+void JsonFormatter::EndArray(_In_ Console& console)
 {
     Pop();
 
     if (!m_arrayStart)
     {
-        out << endl;
+        console.WriteLine();
     }
 
-    out << m_padding << L"]";
+    console.Write(L"%ls]", m_padding.c_str());
 }
 
-void JsonFormatter::EndDocument(_In_ wostream& out)
+void JsonFormatter::EndDocument(_In_ Console& console)
 {
-    out << endl;
+    console.Write(L"\n");
 }
 
 wstring JsonFormatter::FormatDate(_In_ const FILETIME& value)

--- a/src/vswhere.lib/JsonFormatter.h
+++ b/src/vswhere.lib/JsonFormatter.h
@@ -35,14 +35,14 @@ public:
     }
 
 protected:
-    void StartArray(_In_ std::wostream& out) override;
-    void StartObject(_In_ std::wostream& out) override;
-    void WriteProperty(_In_ std::wostream& out, _In_ const std::wstring& name, _In_ const std::wstring& value) override;
-    void WriteProperty(_In_ std::wostream& out, _In_ const std::wstring& name, _In_ bool value) override;
-    void WriteProperty(_In_ std::wostream& out, _In_ const std::wstring& name, _In_ long long value) override;
-    void EndObject(_In_ std::wostream& out) override;
-    void EndArray(_In_ std::wostream& out) override;
-    void EndDocument(_In_ std::wostream& out) override;
+    void StartArray(_In_ Console& console) override;
+    void StartObject(_In_ Console& console) override;
+    void WriteProperty(_In_ Console& console, _In_ const std::wstring& name, _In_ const std::wstring& value) override;
+    void WriteProperty(_In_ Console& console, _In_ const std::wstring& name, _In_ bool value) override;
+    void WriteProperty(_In_ Console& console, _In_ const std::wstring& name, _In_ long long value) override;
+    void EndObject(_In_ Console& console) override;
+    void EndArray(_In_ Console& console) override;
+    void EndDocument(_In_ Console& console) override;
     std::wstring FormatDate(_In_ const FILETIME& value) override;
 
 private:

--- a/src/vswhere.lib/TextFormatter.cpp
+++ b/src/vswhere.lib/TextFormatter.cpp
@@ -7,20 +7,20 @@
 
 using namespace std;
 
-void TextFormatter::StartObject(_In_ std::wostream& out)
+void TextFormatter::StartObject(_In_ Console& console)
 {
     if (m_objectEnd)
     {
-        out << endl;
+        console.WriteLine();
     }
 }
 
-void TextFormatter::WriteProperty(_In_ std::wostream& out, _In_ const std::wstring& name, _In_ const std::wstring& value)
+void TextFormatter::WriteProperty(_In_ Console& console, _In_ const std::wstring& name, _In_ const std::wstring& value)
 {
-    out << name << L": " << value << endl;
+    console.Write(L"%ls: %ls\n", name.c_str(), value.c_str());
 }
 
-void TextFormatter::EndObject(_In_ std::wostream& out)
+void TextFormatter::EndObject(_In_ Console& console)
 {
     m_objectEnd = true;
 }

--- a/src/vswhere.lib/TextFormatter.h
+++ b/src/vswhere.lib/TextFormatter.h
@@ -27,9 +27,9 @@ public:
     }
 
 protected:
-    void StartObject(_In_ std::wostream& out) override;
-    void WriteProperty(_In_ std::wostream& out, _In_ const std::wstring& name, _In_ const std::wstring& value) override;
-    void EndObject(_In_ std::wostream& out) override;
+    void StartObject(_In_ Console& console) override;
+    void WriteProperty(_In_ Console& console, _In_ const std::wstring& name, _In_ const std::wstring& value) override;
+    void EndObject(_In_ Console& console) override;
 
 private:
     bool m_objectEnd;

--- a/src/vswhere.lib/ValueFormatter.cpp
+++ b/src/vswhere.lib/ValueFormatter.cpp
@@ -7,7 +7,7 @@
 
 using namespace std;
 
-void ValueFormatter::WriteProperty(_In_ std::wostream& out, _In_ const std::wstring& name, _In_ const std::wstring& value)
+void ValueFormatter::WriteProperty(_In_ Console& console, _In_ const std::wstring& name, _In_ const std::wstring& value)
 {
-    out << value << endl;
+    console.WriteLine(value);
 }

--- a/src/vswhere.lib/ValueFormatter.h
+++ b/src/vswhere.lib/ValueFormatter.h
@@ -30,5 +30,5 @@ public:
     }
 
 protected:
-    void WriteProperty(_In_ std::wostream& out, _In_ const std::wstring& name, _In_ const std::wstring& value) override;
+    void WriteProperty(_In_ Console& console, _In_ const std::wstring& name, _In_ const std::wstring& value) override;
 };

--- a/src/vswhere.lib/stdafx.h
+++ b/src/vswhere.lib/stdafx.h
@@ -11,6 +11,8 @@
 
 // Windows headers
 #include <windows.h>
+#include <fcntl.h>
+#include <io.h>
 #include <shellapi.h>
 
 // CRT header files
@@ -25,11 +27,8 @@
 #include <codecvt>
 #include <functional>
 #include <iterator>
-#include <iostream>
-#include <locale>
 #include <map>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -47,6 +46,7 @@ _COM_SMARTPTR_TYPEDEF(ISetupPropertyStore, __uuidof(ISetupPropertyStore));
 #include "CoInitializer.h"
 #include "CommandParser.h"
 #include "CommandArgs.h"
+#include "Console.h"
 #include "Formatter.h"
 #include "InstanceSelector.h"
 #include "JsonFormatter.h"

--- a/src/vswhere.lib/vswhere.lib.vcxproj
+++ b/src/vswhere.lib/vswhere.lib.vcxproj
@@ -157,6 +157,7 @@
     </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="Console.h" />
     <ClInclude Include="CoInitializer.h" />
     <ClInclude Include="CommandArgs.h" />
     <ClInclude Include="CommandParser.h" />
@@ -174,6 +175,7 @@
     <ClInclude Include="ValueFormatter.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Console.cpp" />
     <ClCompile Include="CommandArgs.cpp" />
     <ClCompile Include="CommandParser.cpp" />
     <ClCompile Include="Exceptions.cpp" />

--- a/src/vswhere.lib/vswhere.lib.vcxproj.filters
+++ b/src/vswhere.lib/vswhere.lib.vcxproj.filters
@@ -60,6 +60,9 @@
     <ClInclude Include="ValueFormatter.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Console.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -93,6 +96,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="ValueFormatter.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Console.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/vswhere/Program.cpp
+++ b/src/vswhere/Program.cpp
@@ -8,15 +8,14 @@
 using namespace std;
 
 void GetEnumerator(_In_ const CommandArgs& args, _In_ ISetupConfigurationPtr& query, _In_ IEnumSetupInstancesPtr& e);
-void WriteLogo(_In_ const CommandArgs& args, _In_ wostream& out);
+void WriteLogo(_In_ const CommandArgs& args, _In_ Console& console);
 
 int wmain(_In_ int argc, _In_ LPCWSTR argv[])
 {
-    _setmode(_fileno(stdout), _O_U16TEXT);
-
     CommandArgs args;
-    wostream& out = wcout;
+    Console console(args);
 
+    console.Initialize();
     try
     {
         CoInitializer init;
@@ -24,8 +23,8 @@ int wmain(_In_ int argc, _In_ LPCWSTR argv[])
         args.Parse(argc, argv);
         if (args.get_Help())
         {
-            WriteLogo(args, out);
-            args.Usage(out);
+            WriteLogo(args, console);
+            args.Usage(console);
 
             return ERROR_SUCCESS;
         }
@@ -49,10 +48,10 @@ int wmain(_In_ int argc, _In_ LPCWSTR argv[])
         auto formatter = Formatter::Create(args.get_Format());
         if (formatter->ShowLogo())
         {
-            WriteLogo(args, out);
+            WriteLogo(args, console);
         }
 
-        formatter->Write(args, out, instances);
+        formatter->Write(args, console, instances);
         return ERROR_SUCCESS;
     }
     catch (const system_error& ex)
@@ -60,30 +59,30 @@ int wmain(_In_ int argc, _In_ LPCWSTR argv[])
         const auto code = ex.code().value();
         if (ERROR_INVALID_PARAMETER == code)
         {
-            WriteLogo(args, out);
+            WriteLogo(args, console);
         }
 
-        out << ResourceManager::GetString(IDS_ERROR) << L" " << hex << showbase << code << L": ";
+        console.Write(L"%ls 0x%x: ", ResourceManager::GetString(IDS_ERROR).c_str(), code);
 
         const auto* err = dynamic_cast<const win32_error*>(&ex);
         if (err)
         {
-            out << err->wwhat() << endl;
+            console.Write(L"%ls\n", err->wwhat());
         }
         else
         {
-            out << ex.what() << endl;
+            console.Write(L"%hs\n", ex.what());
         }
 
         return ex.code().value();
     }
     catch (const exception& ex)
     {
-        out << ResourceManager::GetString(IDS_ERROR) << L": " << ex.what() << endl;
+        console.Write(L"%ls: %hs\n", ResourceManager::GetString(IDS_ERROR).c_str(), ex.what());
     }
     catch (...)
     {
-        out << ResourceManager::GetString(IDS_ERROR) << L": " << ResourceManager::GetString(IDS_E_UNKNOWN) << endl;
+        console.Write(L"%ls: %ls\n", ResourceManager::GetString(IDS_ERROR).c_str(), ResourceManager::GetString(IDS_E_UNKNOWN).c_str());
     }
 
     return E_FAIL;
@@ -128,12 +127,12 @@ void GetEnumerator(_In_ const CommandArgs& args, _In_ ISetupConfigurationPtr& qu
     }
 }
 
-void WriteLogo(_In_ const CommandArgs& args, _In_ wostream& out)
+void WriteLogo(_In_ const CommandArgs& args, _In_ Console& console)
 {
     if (args.get_Logo())
     {
-        out << ResourceManager::FormatString(IDS_PROGRAMINFO, FILE_VERSION_STRINGW) << endl;
-        out << ResourceManager::GetString(IDS_COPYRIGHT) << endl;
-        out << endl;
+        console.WriteLine(ResourceManager::FormatString(IDS_PROGRAMINFO, FILE_VERSION_STRINGW));
+        console.WriteLine(ResourceManager::GetString(IDS_COPYRIGHT));
+        console.WriteLine();
     }
 }

--- a/src/vswhere/stdafx.h
+++ b/src/vswhere/stdafx.h
@@ -11,8 +11,6 @@
 
 // Windows headers
 #include <windows.h>
-#include <fcntl.h>
-#include <io.h>
 
 // STL headers
 #include <iomanip>

--- a/test/vswhere.test/JsonFormatterTests.cpp
+++ b/test/vswhere.test/JsonFormatterTests.cpp
@@ -14,6 +14,7 @@ public:
     TEST_METHOD(Write_Instance)
     {
         CommandArgs args;
+        TestConsole console(args);
         TestInstance instance =
         {
             { L"InstanceId", L"a1b2c3" },
@@ -22,11 +23,8 @@ public:
         };
 
         JsonFormatter sut;
-        wostringstream ostr;
+        sut.Write(args, console, &instance);
 
-        sut.Write(args, ostr, &instance);
-
-        auto actual = ostr.str();
         auto expected =
             L"[\n"
             L"  {\n"
@@ -36,12 +34,13 @@ public:
             L"  }\n"
             L"]\n";
 
-        Assert::AreEqual(expected, actual.c_str());
+        Assert::AreEqual(expected, console);
     }
 
     TEST_METHOD(Write_Instances)
     {
         CommandArgs args;
+        TestConsole console(args);
         TestInstance instance1 =
         {
             { L"InstanceId", L"a1b2c3" },
@@ -62,11 +61,8 @@ public:
         };
 
         JsonFormatter sut;
-        wostringstream ostr;
+        sut.Write(args, console, instances);
 
-        sut.Write(args, ostr, instances);
-
-        auto actual = ostr.str();
         auto expected =
             L"[\n"
             L"  {\n"
@@ -80,23 +76,21 @@ public:
             L"  }\n"
             L"]\n";
 
-        Assert::AreEqual(expected, actual.c_str());
+        Assert::AreEqual(expected, console);
     }
 
     TEST_METHOD(Write_No_Instances)
     {
         CommandArgs args;
+        TestConsole console(args);
         vector<ISetupInstancePtr> instances;
 
         JsonFormatter sut;
-        wostringstream ostr;
+        sut.Write(args, console, instances);
 
-        sut.Write(args, ostr, instances);
-
-        auto actual = ostr.str();
         auto expected =
             L"[]\n";
 
-        Assert::AreEqual(expected, actual.c_str());
+        Assert::AreEqual(expected, console);
     }
 };

--- a/test/vswhere.test/TestConsole.cpp
+++ b/test/vswhere.test/TestConsole.cpp
@@ -1,0 +1,23 @@
+// <copyright file="TestConsole.h" company="Microsoft Corporation">
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+// </copyright>
+
+#include "stdafx.h"
+
+using namespace std;
+
+void __cdecl TestConsole::Write(_In_ LPCWSTR wzFormat, va_list args)
+{
+    // include space for trailing null character
+    size_t ch = ::_vscwprintf(wzFormat, args) + 1;
+    size_t pos = m_output.size();
+    m_output.resize(m_output.size() + ch);
+
+    size_t rem = m_output.size() - pos;
+    auto end = const_cast<LPWSTR>(m_output.c_str()) + pos;
+    ::vswprintf_s(end, rem, wzFormat, args);
+
+    // remove trailing null character
+    m_output.resize(m_output.size() - 1);
+}

--- a/test/vswhere.test/TestConsole.h
+++ b/test/vswhere.test/TestConsole.h
@@ -1,0 +1,37 @@
+// <copyright file="TestConsole.h" company="Microsoft Corporation">
+// Copyright (C) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+// </copyright>
+
+#pragma once
+
+class TestConsole :
+    public Console
+{
+public:
+    TestConsole(_In_ const CommandArgs& args) :
+        Console(args)
+    {
+    }
+
+    TestConsole(_In_ const TestConsole& obj) :
+        Console(obj),
+        m_output(obj.m_output)
+    {
+    }
+
+    void Initialize() noexcept override
+    {
+    }
+
+    operator const wchar_t*() const
+    {
+        return m_output.c_str();
+    }
+
+protected:
+    void __cdecl Write(_In_ LPCWSTR wzFormat, va_list args) override;
+
+private:
+    std::wstring m_output;
+};

--- a/test/vswhere.test/TextFormatterTests.cpp
+++ b/test/vswhere.test/TextFormatterTests.cpp
@@ -14,6 +14,7 @@ public:
     TEST_METHOD(Write_Instance)
     {
         CommandArgs args;
+        TestConsole console(args);
         TestInstance instance =
         {
             { L"InstanceId", L"a1b2c3" },
@@ -21,21 +22,19 @@ public:
         };
 
         TextFormatter sut;
-        wostringstream ostr;
+        sut.Write(args, console, &instance);
 
-        sut.Write(args, ostr, &instance);
-
-        auto actual = ostr.str();
         auto expected =
             L"instanceId: a1b2c3\n"
             L"installationName: test\n";
 
-        Assert::AreEqual(expected, actual.c_str());
+        Assert::AreEqual(expected, console);
     }
 
     TEST_METHOD(Write_Instances)
     {
         CommandArgs args;
+        TestConsole console(args);
         TestInstance instance1 =
         {
             { L"InstanceId", L"a1b2c3" },
@@ -56,11 +55,8 @@ public:
         };
 
         TextFormatter sut;
-        wostringstream ostr;
+        sut.Write(args, console, instances);
 
-        sut.Write(args, ostr, instances);
-
-        auto actual = ostr.str();
         auto expected =
             L"instanceId: a1b2c3\n"
             L"installationName: test\n"
@@ -69,6 +65,6 @@ public:
             L"installationPath: C:\\ShouldNotExist\n"
             L"installationVersion: 1.2.3.4\n";
 
-        Assert::AreEqual(expected, actual.c_str());
+        Assert::AreEqual(expected, console);
     }
 };

--- a/test/vswhere.test/ValueFormatterTests.cpp
+++ b/test/vswhere.test/ValueFormatterTests.cpp
@@ -16,6 +16,7 @@ public:
         CommandArgs args;
         args.Parse(L"vswhere.exe -property instanceId");
 
+        TestConsole console(args);
         TestInstance instance =
         {
             { L"InstanceId", L"a1b2c3" },
@@ -23,14 +24,11 @@ public:
         };
 
         ValueFormatter sut;
-        wostringstream ostr;
+        sut.Write(args, console, &instance);
 
-        sut.Write(args, ostr, &instance);
-
-        auto actual = ostr.str();
         auto expected = L"a1b2c3\n";
 
-        Assert::AreEqual(expected, actual.c_str());
+        Assert::AreEqual(expected, console);
     }
 
     TEST_METHOD(Write_Instances_Single)
@@ -38,6 +36,7 @@ public:
         CommandArgs args;
         args.Parse(L"vswhere.exe -property InstallationPath");
 
+        TestConsole console(args);
         TestInstance instance1 =
         {
             { L"InstanceId", L"a1b2c3" },
@@ -58,14 +57,11 @@ public:
         };
 
         ValueFormatter sut;
-        wostringstream ostr;
+        sut.Write(args, console, instances);
 
-        sut.Write(args, ostr, instances);
-
-        auto actual = ostr.str();
         auto expected = L"C:\\ShouldNotExist\n";
 
-        Assert::AreEqual(expected, actual.c_str());
+        Assert::AreEqual(expected, console);
     }
 
     TEST_METHOD(Write_Instances)
@@ -73,6 +69,7 @@ public:
         CommandArgs args;
         args.Parse(L"vswhere.exe -property instanceid");
 
+        TestConsole console(args);
         TestInstance instance1 =
         {
             { L"InstanceId", L"a1b2c3" },
@@ -93,15 +90,12 @@ public:
         };
 
         ValueFormatter sut;
-        wostringstream ostr;
+        sut.Write(args, console, instances);
 
-        sut.Write(args, ostr, instances);
-
-        auto actual = ostr.str();
         auto expected =
             L"a1b2c3\n"
             L"b1c2d3\n";
 
-        Assert::AreEqual(expected, actual.c_str());
+        Assert::AreEqual(expected, console);
     }
 };

--- a/test/vswhere.test/stdafx.h
+++ b/test/vswhere.test/stdafx.h
@@ -19,6 +19,7 @@
 // Project headers
 #include <stdafx.h>
 #include "Module.h"
+#include "TestConsole.h"
 #include "TestEnumInstances.h"
 #include "TestHelper.h"
 #include "TestInstance.h"

--- a/test/vswhere.test/vswhere.test.vcxproj
+++ b/test/vswhere.test/vswhere.test.vcxproj
@@ -93,6 +93,7 @@
     <ClInclude Include="resource.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
+    <ClInclude Include="TestConsole.h" />
     <ClInclude Include="TestEnumInstances.h" />
     <ClInclude Include="TestHelper.h" />
     <ClInclude Include="TestInstance.h" />
@@ -108,6 +109,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="TestConsole.cpp" />
     <ClCompile Include="TestHelper.cpp" />
     <ClCompile Include="TextFormatterTests.cpp" />
     <ClCompile Include="UtilitiesTests.cpp" />

--- a/test/vswhere.test/vswhere.test.vcxproj.filters
+++ b/test/vswhere.test/vswhere.test.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClInclude Include="resource.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="TestConsole.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -69,6 +72,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="ValueFormatterTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="TestConsole.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Better fix for issues #11 and #14. Uses the same basic algorithm as the native VC++ compiler so that writing to the console directly will set the mode to Unicode (with BOM); however, redirecting to a file (which various operations in both cmd.exe and powershell.exe do) will use the native console codepage.