### PR TITLE
Update readme with where to find vswhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ _vswhere_ is designed to be a redistributable, single-file executable that can b
 
 You can emit different formats for information based on what your scripts can consume, including plain text, JSON, and XML. Pull requests may be accepted for other common formats as well.
 
+_vswhere_ is included with the installer as of Visual Studio 2017 version 15.2 and later, and can be found at the following location: `C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe`. The binary may be copied from that location as needed for administrative or tooling scripts, or the latest version may be compiled from the source code in this repo.  
+
 ## Example
 
 If you wanted to find MSBuild - now installed under the Visual Studio 2017 and newer installation root - you could script a command like the following to find the latest version installed.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ _vswhere_ is designed to be a redistributable, single-file executable that can b
 
 You can emit different formats for information based on what your scripts can consume, including plain text, JSON, and XML. Pull requests may be accepted for other common formats as well.
 
-_vswhere_ is included with the installer as of Visual Studio 2017 version 15.2 and later, and can be found at the following location: `C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe`. The binary may be copied from that location as needed for administrative or tooling scripts, or the latest version may be compiled from the source code in this repo.  
+_vswhere_ is included with the installer as of Visual Studio 2017 version 15.2 and later, and can be found at the following location: `%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe`. The binary may be copied from that location as needed, [installed from Chocolatey](https://chocolatey.org/packages/vswhere), or the latest version may be compiled from the source code in this repo.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ _vswhere_ is designed to be a redistributable, single-file executable that can b
 
 You can emit different formats for information based on what your scripts can consume, including plain text, JSON, and XML. Pull requests may be accepted for other common formats as well.
 
-_vswhere_ is included with the installer as of Visual Studio 2017 version 15.2 and later, and can be found at the following location: `%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe`. The binary may be copied from that location as needed, [installed from Chocolatey](https://chocolatey.org/packages/vswhere), or the latest version may be compiled from the source code in this repo.
+_vswhere_ is included with the installer as of Visual Studio 2017 version 15.2 and later, and can be found at the following location: `%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe`. The binary may be copied from that location as needed, [installed using Chocolatey](https://chocolatey.org/packages/vswhere), or the latest version may be [downloaded from the releases page](https://github.com/Microsoft/vswhere/releases). More information about how to get _vswhere_ is [on the wiki](https://github.com/Microsoft/vswhere/wiki/Installing). 
 
 ## Example
 


### PR DESCRIPTION
Added a short paragraph to note that this is included in-box in 15.2 and can be confidently found at a specific location on machines with that release installed. Version number format confirmed against internal guidance.