### PR TITLE
Use "choco pack" with custom metadata

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="chocolatey" version="0.10.8" />
   <package id="vswhere" version="1.0.62" />
 </packages>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ build:
   parallel: true
 
 after_build:
-  - nuget pack -OutputDirectory "bin\%CONFIGURATION%" -Version "%GitBuildVersionSimple%" -Properties "Configuration=%CONFIGURATION%;CommitId=%APPVEYOR_REPO_COMMIT%" pkg\vswhere\vswhere.nuspec
+  - tools\choco.cmd pack pkg\vswhere\vswhere.nuspec --out "bin\%CONFIGURATION%" --version "%GitBuildVersionSimple%" "Configuration=%CONFIGURATION%" "CommitId=%APPVEYOR_REPO_COMMIT%"
 
 test_script:
   - tools\test.cmd -v

--- a/pkg/vswhere/packages.config
+++ b/pkg/vswhere/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Nerdbank.GitVersioning" version="1.5.97" targetFramework="native" developmentDependency="true" />
-</packages>

--- a/pkg/vswhere/vswhere.nuspec
+++ b/pkg/vswhere/vswhere.nuspec
@@ -15,10 +15,11 @@
     <copyright>Copyright (C) Microsoft Corporation. All rights reserved.</copyright>
     <tags>vs vs2017 visualstudio</tags>
     <developmentDependency>true</developmentDependency>
-    <!--packageSourceUrl>https://github.com/Microsoft/vswhere/tree/$CommitId$/pkg/vswhere</packageSourceUrl-->
-    <!--docsUrl>https://github.com/Microsoft/vswhere/wiki</docsUrl-->
-    <!--bugTrackerUrl>https://github.com/Microsoft/vswhere/issues</bugTrackerUrl-->
-    <!--projectSourceUrl>https://github.com/Microsoft/vswhere/tree/$CommitId$</projectSourceUrl-->
+    <projectSourceUrl>https://github.com/Microsoft/vswhere/tree/$CommitId$</projectSourceUrl>
+    <packageSourceUrl>https://github.com/Microsoft/vswhere/tree/$CommitId$/pkg/vswhere</packageSourceUrl>
+    <docsUrl>https://github.com/Microsoft/vswhere/wiki</docsUrl>
+    <bugTrackerUrl>https://github.com/Microsoft/vswhere/issues</bugTrackerUrl>
+    <releaseNotes>https://github.com/Microsoft/vswhere/releases/tag/$Version$</releaseNotes>
   </metadata>
   <files>
     <file src="build\vswhere.props" target="build\"/>

--- a/tools/choco.cmd
+++ b/tools/choco.cmd
@@ -1,0 +1,9 @@
+@if not defined _echo echo off
+setlocal enabledelayedexpansion
+
+for /d %%i in ("%~dp0..\packages\chocolatey*") do (
+    for /f "usebackq delims=" %%j in (`where /r "%%i" choco.exe 2^>nul`) do (
+        "%%j" %*
+        exit /b !errorlevel!
+    )
+)


### PR DESCRIPTION
Now that the change for chocolatey/choco#1313 has been released in
version 0.10.8 use "choco pack" to add custom metadata for
chocolatey.org.