### PR TITLE
Improve tests for -latest

### DIFF
--- a/docker/Instances/1/state.json
+++ b/docker/Instances/1/state.json
@@ -3,7 +3,7 @@
     "installationName": "VisualStudio/public.d15rel/15.0.26116.0",
     "installationVersion": "15.0.26116",
     "installationPath": "C:\\VS\\Community",
-    "installDate": "2017-01-17T03:00:00Z",
+    "installDate": "2017-01-17T03:45:00Z",
     "product": {
         "id": "Microsoft.VisualStudio.Product.Community",
         "version": "15.0.26116.0",


### PR DESCRIPTION
A bug was found in the VSSetup.PowerShell project that didn't correctly implement -latest. vswhere did but I wanted to unify the tests to make sure the right behavior is not regressed.