### PR TITLE
Eliminate string format in exception handler

### DIFF
--- a/docker/Tests/vswhere.tests.ps1
+++ b/docker/Tests/vswhere.tests.ps1
@@ -200,6 +200,11 @@ Describe 'vswhere' {
             @($instances.instances.instance).Count | Should Be 1
             @($instances.instances.instance)[0].instanceId | Should Be 2
         }
+
+        It 'does not crash when passed %0' {
+            $message = C:\bin\vswhere.exe -version '%0'
+            $message[-1] | Should Be 'Error 0x57: The version "%0" is not a valid version range'
+        }
     }
 
     Context '-latest' {

--- a/inc/Common.Debug.props
+++ b/inc/Common.Debug.props
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <LanguageStandard>stdcpp14</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Lib>

--- a/inc/Common.props
+++ b/inc/Common.props
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
+      <LanguageStandard>stdcpp14</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Lib>

--- a/src/vswhere/Program.cpp
+++ b/src/vswhere/Program.cpp
@@ -92,7 +92,7 @@ int wmain(_In_ int argc, _In_ LPCWSTR argv[])
         const auto* err = dynamic_cast<const win32_error*>(&ex);
         if (err)
         {
-            console.WriteLine(err->wwhat());
+            console.WriteLine((wstring)err->wwhat());
         }
         else
         {

--- a/src/vswhere/Program.cpp
+++ b/src/vswhere/Program.cpp
@@ -92,7 +92,7 @@ int wmain(_In_ int argc, _In_ LPCWSTR argv[])
         const auto* err = dynamic_cast<const win32_error*>(&ex);
         if (err)
         {
-            console.WriteLine((wstring)err->wwhat());
+            console.WriteLine(L"%ls", err->wwhat());
         }
         else
         {


### PR DESCRIPTION
When argument value including format string such as "%0" is provided, vswhere will crash.