### PR TITLE
Without "delims=" the batch file will not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ If you wanted to find MSBuild - now installed under the Visual Studio 2017 and n
 ```batch
 @echo off
 setlocal enabledelayedexpansion
-
-for /f "usebackq tokens=*" %%i in (`vswhere -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do (
+for /f "usebackq delims=" %%i in (`"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere" -latest -products * -requires Microsoft.VisualStudio.Workload.ManagedDesktop Microsoft.VisualStudio.Workload.Web -requiresAny -property installationPath`) do (
   "%%i" %*
   exit /b !errorlevel!
 )


### PR DESCRIPTION
In real life, the path returned by vswhere will contain spaces, thus the batch file example will not work at all.

Furthermore, vswhere is supposed to always reside in the "safe place":
"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere"