### PR TITLE
Update AzDO build to use new 1ES pool

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -14,7 +14,7 @@ trigger:
 pr: none
 
 queue:
-  name: VSEngSS-MicroBuild2019
+  name: VSEngSS-MicroBuild2019-1ES
   timeoutInMinutes: 120
   demands: 
   - ChocolateyInstall


### PR DESCRIPTION
Self-Hosted pools are being deprecated in favor of 1ES pools.