### PR TITLE
Add compliance build and update minimum supported OS to Windows 7

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -14,7 +14,7 @@
     "Microsoft.VisualStudio.Component.VC.DiagnosticTools",
     "Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
     "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core",
-    "Microsoft.VisualStudio.Component.Windows10SDK.16299",
+    "Microsoft.VisualStudio.Component.Windows10SDK.17763",
     "Microsoft.VisualStudio.Component.VC.v141.x86.x64",
     "Microsoft.VisualStudio.Workload.NativeDesktop",
     "Microsoft.VisualStudio.Component.Git",

--- a/.vsts-compliance.yml
+++ b/.vsts-compliance.yml
@@ -1,0 +1,78 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - master
+    - develop
+  paths:
+    exclude:
+    - README.md
+
+pr: none
+
+queue:
+  name: VSEngSS-MicroBuild2019-1ES
+  timeoutInMinutes: 120
+  demands: 
+  - ChocolateyInstall
+  - MSBuild
+  - VisualStudio
+  - VSTest
+
+steps:
+- template: inc/build.yml
+  parameters:
+      BuildConfiguration: $(BuildConfiguration)
+      BuildPlatform: $(BuildPlatform)
+      Sign: false
+
+- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  displayName: Detect components
+  inputs:
+    sourceScanPath: $(Build.SourcesDirectory)
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-prefast.SDLNativeRules@2
+  displayName: 'Run the PREfast SDL Native Rules for MSBuild'
+  continueOnError: true
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+  displayName: 'Run PoliCheck'
+  inputs:
+    targetType: F
+    targetArgument: '$(Build.SourcesDirectory)'
+    optionsFC: 0
+    optionsXS: 1
+    optionsHMENABLE: 0
+  continueOnError: true
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
+  displayName: 'Run BinSkim'
+  inputs:
+    InputType: Basic
+    Function: analyze
+    AnalyzeTarget: 'bin\$(BuildConfiguration)\*.exe'
+    AnalyzeSymPath: 'bin\$(BuildConfiguration)'
+    AnalyzeVerbose: true
+    AnalyzeHashes: true
+  continueOnError: true
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+  displayName: 'Run CredScan'
+  inputs:
+    debugMode: false
+
+# Publish compliance results
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
+  displayName: 'Publish Security Analysis Logs'
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+  displayName: Check SDL results
+  inputs:
+    AllTools: true
+
+- task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
+  displayName: Clean up
+  condition: succeededOrFailed()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@
 # Licensed under the MIT license. See LICENSE.txt in the project root for license information.
 
 # Based on latest image cached by Azure Pipelines: https://docs.microsoft.com/azure/devops/pipelines/agents/hosted#software
-FROM microsoft/windowsservercore@sha256:ac71e33f27c2a6b5db30be0419458e0c4e926214bc9c85afd4d6d6f9028d7233
+FROM microsoft/windowsservercore@sha256:22cc6661c975edc09fa44c497f8310b264da4ff102a56a974e4cf1a790626a22
 SHELL ["powershell.exe", "-ExecutionPolicy", "Bypass", "-Command"]
 
 ENV INSTALLER_VERSION=1.14.190.31519 `

--- a/src/vswhere.lib/CommandArgs.cpp
+++ b/src/vswhere.lib/CommandArgs.cpp
@@ -110,9 +110,9 @@ void CommandArgs::Parse(_In_ vector<CommandParser::Token> args)
         else if (ArgumentEquals(arg.Value, L"format"))
         {
             auto format = ParseArgument(it, args.end(), arg);
-            auto it = Formatter::Formatters.find(format);
+            auto formatIt = Formatter::Formatters.find(format);
 
-            if (it != Formatter::Formatters.end())
+            if (formatIt != Formatter::Formatters.end())
             {
                 m_format = format;
             }

--- a/src/vswhere.lib/CommandArgs.cpp
+++ b/src/vswhere.lib/CommandArgs.cpp
@@ -110,9 +110,9 @@ void CommandArgs::Parse(_In_ vector<CommandParser::Token> args)
         else if (ArgumentEquals(arg.Value, L"format"))
         {
             auto format = ParseArgument(it, args.end(), arg);
-            auto formatIt = Formatter::Formatters.find(format);
+            auto formatterIt = Formatter::Formatters.find(format);
 
-            if (formatIt != Formatter::Formatters.end())
+            if (formatterIt != Formatter::Formatters.end())
             {
                 m_format = format;
             }

--- a/src/vswhere.lib/CommandParser.cpp
+++ b/src/vswhere.lib/CommandParser.cpp
@@ -20,7 +20,7 @@ vector<CommandParser::Token> CommandParser::Parse(_In_ LPCWSTR wszCommandLine)
     }
 
     // Make sure the argument array is released when it falls out of scope.
-    unique_ptr<LPWSTR*, void(*)(LPWSTR**)> args(&argv, [](LPWSTR** ppwsz)
+    unique_ptr<LPWSTR*, void(*)(LPWSTR**)> args(&argv, [](_In_opt_ LPWSTR** ppwsz)
     {
         if (ppwsz)
         {

--- a/src/vswhere.lib/Console.cpp
+++ b/src/vswhere.lib/Console.cpp
@@ -13,16 +13,16 @@ void Console::Initialize() noexcept
     {
         if (m_args.get_UTF8())
         {
-            ::_setmode(_fileno(stdout), _O_U8TEXT);
+            static_cast<void>(::_setmode(_fileno(stdout), _O_U8TEXT));
         }
         else if (IsConsole(stdout))
         {
-            ::_setmode(_fileno(stdout), _O_WTEXT);
+            static_cast<void>(::_setmode(_fileno(stdout), _O_WTEXT));
         }
         else
         {
             char sz[10];
-            ::sprintf_s(sz, ".%d", ::GetConsoleCP());
+            ::sprintf_s(sz, ".%u", ::GetConsoleCP());
 
             ::setlocale(LC_CTYPE, sz);
         }
@@ -66,7 +66,7 @@ void __cdecl Console::Write(_In_ const std::wstring& value)
     Write(value.c_str(), NULL);
 }
 
-void __cdecl Console::WriteLine(_In_ LPCWSTR wzFormat, ...)
+void __cdecl Console::WriteLine(_In_opt_ LPCWSTR wzFormat, ...)
 {
     if (wzFormat)
     {
@@ -80,7 +80,7 @@ void __cdecl Console::WriteLine(_In_ LPCWSTR wzFormat, ...)
     Write(L"\n", NULL);
 }
 
-void __cdecl Console::WriteLine(_In_ const std::wstring& value)
+void __cdecl Console::WriteLine(_In_opt_ const std::wstring& value)
 {
     Write(L"%ls\n", value.c_str());
 }

--- a/src/vswhere.lib/Console.cpp
+++ b/src/vswhere.lib/Console.cpp
@@ -80,7 +80,7 @@ void __cdecl Console::WriteLine(_In_opt_ LPCWSTR wzFormat, ...)
     Write(L"\n", NULL);
 }
 
-void __cdecl Console::WriteLine(_In_opt_ const std::wstring& value)
+void __cdecl Console::WriteLine(_In_ const std::wstring& value)
 {
     Write(L"%ls\n", value.c_str());
 }

--- a/src/vswhere.lib/Console.cpp
+++ b/src/vswhere.lib/Console.cpp
@@ -121,9 +121,6 @@ bool Console::IsVirtualTerminal(_In_ FILE* f) noexcept
     DWORD dwMode;
     if (::GetConsoleMode(hFile, &dwMode))
     {
-        // Defined in newer SDK but can try to enable on older platforms.
-        const DWORD ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x4;
-
         return 0 != ::SetConsoleMode(hFile, dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
     }
 

--- a/src/vswhere.lib/Console.h
+++ b/src/vswhere.lib/Console.h
@@ -30,7 +30,7 @@ public:
     void __cdecl Write(_In_ LPCWSTR wzFormat, ...);
     void __cdecl Write(_In_ const std::wstring& value);
     void __cdecl WriteLine(_In_opt_ LPCWSTR wzFormat = NULL, ...);
-    void __cdecl WriteLine(_In_opt_ const std::wstring& value);
+    void __cdecl WriteLine(_In_ const std::wstring& value);
 
     virtual bool IsColorSupported() const
     {

--- a/src/vswhere.lib/Console.h
+++ b/src/vswhere.lib/Console.h
@@ -29,8 +29,8 @@ public:
 
     void __cdecl Write(_In_ LPCWSTR wzFormat, ...);
     void __cdecl Write(_In_ const std::wstring& value);
-    void __cdecl WriteLine(_In_ LPCWSTR wzFormat = NULL, ...);
-    void __cdecl WriteLine(_In_ const std::wstring& value);
+    void __cdecl WriteLine(_In_opt_ LPCWSTR wzFormat = NULL, ...);
+    void __cdecl WriteLine(_In_opt_ const std::wstring& value);
 
     virtual bool IsColorSupported() const
     {

--- a/src/vswhere.lib/Formatter.cpp
+++ b/src/vswhere.lib/Formatter.cpp
@@ -495,6 +495,7 @@ HRESULT Formatter::GetInstanceId(_In_ ISetupInstance* pInstance, _Out_ VARIANT* 
     return GetStringProperty(bind(&ISetupInstance::GetInstanceId, pInstance, _1), pvtInstanceId);
 }
 
+#pragma warning(suppress: 6101) // pvtInstallDate is not set if value is empty but we still return success
 HRESULT Formatter::GetInstallDate(_In_ ISetupInstance* pInstance, _Out_ VARIANT* pvtInstallDate)
 {
     FILETIME ft = {};
@@ -514,10 +515,6 @@ HRESULT Formatter::GetInstallDate(_In_ ISetupInstance* pInstance, _Out_ VARIANT*
 
             vt.vt = VT_BSTR;
             *pvtInstallDate = vt.Detach();
-        }
-        else
-        {
-            hr = E_FAIL;
         }
     }
 
@@ -539,6 +536,7 @@ HRESULT Formatter::GetInstallationVersion(_In_ ISetupInstance* pInstance, _Out_ 
     return GetStringProperty(bind(&ISetupInstance::GetInstallationVersion, pInstance, _1), pvtInstallationVersion);
 }
 
+#pragma warning(suppress: 6101) // pvtProductId is not set if instance product is null but we still return success
 HRESULT Formatter::GetProductId(_In_ ISetupInstance* pInstance, _Out_ VARIANT* pvtProductId)
 {
     ISetupInstance2Ptr instance;
@@ -560,15 +558,12 @@ HRESULT Formatter::GetProductId(_In_ ISetupInstance* pInstance, _Out_ VARIANT* p
                 *pvtProductId = vt.Detach();
             }
         }
-        else if (SUCCEEDED(hr))
-        {
-            hr = E_FAIL;
-        }
     }
 
     return hr;
 }
 
+#pragma warning(suppress: 6101) // pvtProductPath is not set if product path is null but we still return success
 HRESULT Formatter::GetProductPath(_In_ ISetupInstance* pInstance, _Out_ VARIANT* pvtProductPath)
 {
     ISetupInstance2Ptr instance;
@@ -589,10 +584,6 @@ HRESULT Formatter::GetProductPath(_In_ ISetupInstance* pInstance, _Out_ VARIANT*
                 vt.vt = VT_BSTR;
                 *pvtProductPath = vt.Detach();
             }
-        }
-        else if (SUCCEEDED(hr))
-        {
-            hr = E_FAIL;
         }
     }
 

--- a/src/vswhere.lib/Formatter.cpp
+++ b/src/vswhere.lib/Formatter.cpp
@@ -62,7 +62,7 @@ std::unique_ptr<Formatter> Formatter::Create(_In_ const wstring& type, _In_ Comm
     throw win32_error(ERROR_NOT_SUPPORTED);
 }
 
-void Formatter::Write(const std::wstring& root, _In_ const std::wstring& name, _In_ const std::vector<std::wstring> values)
+void Formatter::Write(_In_ const std::wstring& root, _In_ const std::wstring& name, _In_ const std::vector<std::wstring> values)
 {
     StartDocument();
     StartArray(root);
@@ -101,7 +101,7 @@ void Formatter::Write(_In_ vector<ISetupInstancePtr> instances)
     EndDocument();
 }
 
-void Formatter::WriteFiles(vector<ISetupInstancePtr> instances)
+void Formatter::WriteFiles(_In_ vector<ISetupInstancePtr> instances)
 {
     StartDocument();
     StartArray(L"files");
@@ -136,7 +136,7 @@ wstring Formatter::FormatDateISO8601(_In_ const FILETIME& value)
     }
 
     wchar_t wz[21] = {};
-    auto cch = ::swprintf_s(wz, L"%04d-%02d-%02dT%02d:%02d:%02dZ", st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
+    auto cch = ::swprintf_s(wz, L"%04u-%02u-%02uT%02u:%02u:%02uZ", st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
 
     return wstring(wz, cch);
 }
@@ -515,6 +515,10 @@ HRESULT Formatter::GetInstallDate(_In_ ISetupInstance* pInstance, _Out_ VARIANT*
             vt.vt = VT_BSTR;
             *pvtInstallDate = vt.Detach();
         }
+        else
+        {
+            hr = E_FAIL;
+        }
     }
 
     return hr;
@@ -556,6 +560,10 @@ HRESULT Formatter::GetProductId(_In_ ISetupInstance* pInstance, _Out_ VARIANT* p
                 *pvtProductId = vt.Detach();
             }
         }
+        else if (SUCCEEDED(hr))
+        {
+            hr = E_FAIL;
+        }
     }
 
     return hr;
@@ -581,6 +589,10 @@ HRESULT Formatter::GetProductPath(_In_ ISetupInstance* pInstance, _Out_ VARIANT*
                 vt.vt = VT_BSTR;
                 *pvtProductPath = vt.Detach();
             }
+        }
+        else if (SUCCEEDED(hr))
+        {
+            hr = E_FAIL;
         }
     }
 

--- a/src/vswhere.lib/Formatter.cpp
+++ b/src/vswhere.lib/Formatter.cpp
@@ -495,7 +495,7 @@ HRESULT Formatter::GetInstanceId(_In_ ISetupInstance* pInstance, _Out_ VARIANT* 
     return GetStringProperty(bind(&ISetupInstance::GetInstanceId, pInstance, _1), pvtInstanceId);
 }
 
-#pragma warning(suppress: 6101) // pvtInstallDate is not set if value is empty but we still return success
+#pragma warning(suppress: 6101) // pvtInstallDate is not set if value is empty, but it should be empty so we still return success
 HRESULT Formatter::GetInstallDate(_In_ ISetupInstance* pInstance, _Out_ VARIANT* pvtInstallDate)
 {
     FILETIME ft = {};
@@ -536,7 +536,7 @@ HRESULT Formatter::GetInstallationVersion(_In_ ISetupInstance* pInstance, _Out_ 
     return GetStringProperty(bind(&ISetupInstance::GetInstallationVersion, pInstance, _1), pvtInstallationVersion);
 }
 
-#pragma warning(suppress: 6101) // pvtProductId is not set if instance product is null but we still return success
+#pragma warning(suppress: 6101) // pvtProductId is not set if instance product is null, but it should be empty so we still return success
 HRESULT Formatter::GetProductId(_In_ ISetupInstance* pInstance, _Out_ VARIANT* pvtProductId)
 {
     ISetupInstance2Ptr instance;
@@ -563,7 +563,7 @@ HRESULT Formatter::GetProductId(_In_ ISetupInstance* pInstance, _Out_ VARIANT* p
     return hr;
 }
 
-#pragma warning(suppress: 6101) // pvtProductPath is not set if product path is null but we still return success
+#pragma warning(suppress: 6101) // pvtProductPath is not set if product path is null, but it should be empty so we still return success
 HRESULT Formatter::GetProductPath(_In_ ISetupInstance* pInstance, _Out_ VARIANT* pvtProductPath)
 {
     ISetupInstance2Ptr instance;

--- a/src/vswhere.lib/LegacyInstance.cpp
+++ b/src/vswhere.lib/LegacyInstance.cpp
@@ -8,7 +8,7 @@
 using namespace std;
 
 template <class T>
-inline HRESULT NotImplemented(_In_ T* p)
+inline HRESULT NotImplemented(_Out_opt_ T* p)
 {
     if (!p)
     {
@@ -20,7 +20,7 @@ inline HRESULT NotImplemented(_In_ T* p)
 }
 
 template<>
-inline HRESULT NotImplemented(_In_ LPFILETIME pft)
+inline HRESULT NotImplemented(_Out_opt_ LPFILETIME pft)
 {
     if (!pft)
     {

--- a/src/vswhere.lib/Module.cpp
+++ b/src/vswhere.lib/Module.cpp
@@ -50,7 +50,7 @@ const wstring& Module::get_FileVersion() noexcept
     }
 
     vector<byte> buffer(cbVersionInfo);
-    if (!::GetFileVersionInfoW(path.c_str(), dwHandle, buffer.size(), buffer.data()))
+    if (!::GetFileVersionInfoW(path.c_str(), 0, buffer.size(), buffer.data()))
     {
         return m_fileVersion;
     }
@@ -63,7 +63,7 @@ const wstring& Module::get_FileVersion() noexcept
     }
 
     auto cch = _scwprintf(
-        L"%d.%d.%d.%d",
+        L"%u.%u.%u.%u",
         (pFileInfo->dwFileVersionMS >> 16) & 0xffff,
         pFileInfo->dwFileVersionMS & 0xffff,
         (pFileInfo->dwFileVersionLS >> 16) & 0xffff,
@@ -77,7 +77,7 @@ const wstring& Module::get_FileVersion() noexcept
     swprintf_s(
         const_cast<LPWSTR>(m_fileVersion.c_str()),
         m_fileVersion.size(),
-        L"%d.%d.%d.%d",
+        L"%u.%u.%u.%u",
         (pFileInfo->dwFileVersionMS >> 16) & 0xffff,
         pFileInfo->dwFileVersionMS & 0xffff,
         (pFileInfo->dwFileVersionLS >> 16) & 0xffff,

--- a/src/vswhere.lib/targetver.h
+++ b/src/vswhere.lib/targetver.h
@@ -11,6 +11,6 @@
 #undef  _WIN32_WINNT
 #endif
 
-#define _WIN32_WINNT 0x0501
+#define _WIN32_WINNT 0x601
 
 #include <sdkddkver.h>

--- a/src/vswhere.lib/vswhere.lib.vcxproj
+++ b/src/vswhere.lib/vswhere.lib.vcxproj
@@ -15,20 +15,20 @@
     <ProjectGuid>{4CCF39CB-4794-44E2-AA57-D215F13CF606}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>vswherelib</RootNamespace>
-    <TargetUniversalCRTVersion>10.0.16299.0</TargetUniversalCRTVersion>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <TargetUniversalCRTVersion>10.0.17763.0</TargetUniversalCRTVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/src/vswhere.lib/vswhere.lib.vcxproj
+++ b/src/vswhere.lib/vswhere.lib.vcxproj
@@ -59,6 +59,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -83,6 +84,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/vswhere/targetver.h
+++ b/src/vswhere/targetver.h
@@ -11,6 +11,6 @@
 #undef  _WIN32_WINNT
 #endif
 
-#define _WIN32_WINNT 0x0501
+#define _WIN32_WINNT 0x601
 
 #include <sdkddkver.h>

--- a/src/vswhere/vswhere.vcxproj
+++ b/src/vswhere/vswhere.vcxproj
@@ -63,6 +63,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -82,6 +83,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/vswhere/vswhere.vcxproj
+++ b/src/vswhere/vswhere.vcxproj
@@ -16,20 +16,20 @@
     <ProjectGuid>{210864F0-9A29-4479-B830-B802EE3F4D92}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>vswhere</RootNamespace>
-    <TargetUniversalCRTVersion>10.0.16299.0</TargetUniversalCRTVersion>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <TargetUniversalCRTVersion>10.0.17763.0</TargetUniversalCRTVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/test/vswhere.test/TestEnumInstances.h
+++ b/test/vswhere.test/TestEnumInstances.h
@@ -66,16 +66,16 @@ public:
     STDMETHODIMP Next(
         _In_ ULONG celt,
         _Out_writes_to_(celt, *pceltFetched) ISetupInstance** rgelt,
-        _Out_opt_ _Deref_out_range_(0, celt) ULONG* pceltFetched
+        _Out_ _Deref_out_range_(0, celt) ULONG* pceltFetched
     )
     {
+        *pceltFetched = 0;
         auto remaining = m_instances.size() - m_i;
         if (0 == remaining)
         {
             return S_FALSE;
         }
-
-        *pceltFetched = 0;
+        
         for (unsigned long i = 0; i < celt && m_i < m_instances.size(); ++i, ++m_i, ++*pceltFetched)
         {
             rgelt[i] = m_instances[m_i];

--- a/test/vswhere.test/TestInstance.h
+++ b/test/vswhere.test/TestInstance.h
@@ -101,6 +101,7 @@ public:
         return TryGetBSTR(L"InstanceId", pbstrInstanceId);
     }
 
+    #pragma warning(suppress: 6101) // pInstallDate is not set if value is an invalid date but we still return success
     STDMETHODIMP GetInstallDate(
         _Out_ LPFILETIME pInstallDate)
     {
@@ -115,10 +116,6 @@ public:
             if (num_fields == ::swscanf_s(value.c_str(), L"%hu-%hu-%huT%hu:%hu:%hu", &st.wYear, &st.wMonth, &st.wDay, &st.wHour, &st.wMinute, &st.wSecond))
             {
                 ::SystemTimeToFileTime(&st, pInstallDate);
-            }
-            else
-            {
-                hr = E_FAIL;
             }
         }
 

--- a/test/vswhere.test/TestInstance.h
+++ b/test/vswhere.test/TestInstance.h
@@ -112,9 +112,13 @@ public:
             const int num_fields = 6;
             SYSTEMTIME st = {};
 
-            if (num_fields == ::swscanf_s(value.c_str(), L"%hd-%hd-%hdT%hd:%hd:%hd", &st.wYear, &st.wMonth, &st.wDay, &st.wHour, &st.wMinute, &st.wSecond))
+            if (num_fields == ::swscanf_s(value.c_str(), L"%hu-%hu-%huT%hu:%hu:%hu", &st.wYear, &st.wMonth, &st.wDay, &st.wHour, &st.wMinute, &st.wSecond))
             {
                 ::SystemTimeToFileTime(&st, pInstallDate);
+            }
+            else
+            {
+                hr = E_FAIL;
             }
         }
 

--- a/test/vswhere.test/TestModule.cpp
+++ b/test/vswhere.test/TestModule.cpp
@@ -37,5 +37,6 @@ wstring __cdecl format(_In_ LPCWSTR fmt, ...)
 
 TEST_MODULE_INITIALIZE(ModuleInitialize)
 {
+    #pragma warning(suppress: 6387) // Ignore potential failure when getting module handle
     ResourceManager::SetInstance(::GetModuleHandleW(L"vswhere.test.dll"));
 }

--- a/test/vswhere.test/TestPropertyStore.h
+++ b/test/vswhere.test/TestPropertyStore.h
@@ -147,7 +147,7 @@ private:
         }
 
         static ci_equal equals;
-        VARENUM vt;
+        VARENUM vt = VT_EMPTY;
         std::wstring value;
 
         auto hr = TryGet(wszName, vt, value);

--- a/test/vswhere.test/VersionRangeTests.cpp
+++ b/test/vswhere.test/VersionRangeTests.cpp
@@ -17,6 +17,7 @@ public:
         auto pHelper = new VersionRange;
         ISetupHelperPtr sut(pHelper, false);
 
+        #pragma warning(suppress: 6387) // Expected to pass invalid arg
         Assert::AreEqual(E_INVALIDARG, sut->ParseVersion(NULL, NULL));
     }
 
@@ -25,6 +26,7 @@ public:
         auto pHelper = new VersionRange;
         ISetupHelperPtr sut(pHelper, false);
 
+        #pragma warning(suppress: 6387) // Expected to pass invalid arg
         Assert::AreEqual(E_POINTER, sut->ParseVersion(L"1.0", NULL));
     }
 
@@ -130,6 +132,7 @@ public:
         auto pHelper = new VersionRange;
         ISetupHelperPtr sut(pHelper, false);
 
+        #pragma warning(suppress: 6387) // Expected to pass invalid arg
         Assert::AreEqual(E_INVALIDARG, sut->ParseVersionRange(NULL, NULL, NULL));
     }
 
@@ -138,6 +141,7 @@ public:
         auto pHelper = new VersionRange;
         ISetupHelperPtr sut(pHelper, false);
 
+        #pragma warning(suppress: 6387) // Expected to pass invalid arg
         Assert::AreEqual(E_POINTER, sut->ParseVersionRange(L"[1.0,)", NULL, NULL));
     }
 
@@ -147,6 +151,8 @@ public:
         ISetupHelperPtr sut(pHelper, false);
 
         ULONGLONG ullMinVersion = 0;
+
+        #pragma warning(suppress: 6387) // Expected to pass invalid arg
         Assert::AreEqual(E_POINTER, sut->ParseVersionRange(L"[1.0,)", &ullMinVersion, NULL));
     }
 

--- a/test/vswhere.test/targetver.h
+++ b/test/vswhere.test/targetver.h
@@ -11,6 +11,6 @@
 #undef  _WIN32_WINNT
 #endif
 
-#define _WIN32_WINNT 0x0501
+#define _WIN32_WINNT 0x601
 
 #include <sdkddkver.h>

--- a/test/vswhere.test/vswhere.test.vcxproj
+++ b/test/vswhere.test/vswhere.test.vcxproj
@@ -16,22 +16,22 @@
     <ProjectGuid>{76268871-D5A5-46BD-9805-41DB1C3072D1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>vswheretest</RootNamespace>
-    <TargetUniversalCRTVersion>10.0.16299.0</TargetUniversalCRTVersion>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <TargetUniversalCRTVersion>10.0.17763.0</TargetUniversalCRTVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 ﻿{
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.9",
+  "version": "3.0",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/tags/v\\d+\\.\\d+"


### PR DESCRIPTION
To make the repo compliant, a set of compliance tasks needs to be run. This adds the compliance tasks and fixes all errors that were flagged.

The Prefast compliance task doesn't support Windows XP, so we need to update the targeting to Windows 7.

Since it is a breaking change in OS support, the major version is increasing.