### PR TITLE
Removing dependency on non-compliant and outdated vswhere test package

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" />
-  <package id="vswhere" version="1.0.62" />
 </packages>

--- a/tools/test.ps1
+++ b/tools/test.ps1
@@ -34,9 +34,9 @@ if ($Type -contains 'Unit' -or $Type -contains 'Functional')
     # Find vstest.console.exe.
     $cmd = get-command vstest.console.exe -ea SilentlyContinue | select-object -expand Path
     if (-not $cmd) {
-        $vswhere = get-childitem "$PSScriptRoot\..\packages\vswhere*" -filter vswhere.exe -recurse | select-object -first 1 -expand FullName
+        $vswhere = get-childitem "$PSScriptRoot\..\bin\*" -filter vswhere.exe -recurse | select-object -first 1 -expand FullName
         if (-not $vswhere) {
-            write-error 'Please run "nuget restore" on the solution to download vswhere.'
+            write-error 'Please build vswhere before running tests.'
             exit 1
         }
 


### PR DESCRIPTION
The current `test.ps1` has a dependency on a very old and non-compliant version of `vswhere`.

I've removed this self-referential package to reference the current built version of `vswhere` instead. To me, this is a reasonable compromise, since it has to build to run the tests later in the script.