### PR TITLE
Provide weekly schedule for vswhere compliance run

### DIFF
--- a/.vsts-compliance.yml
+++ b/.vsts-compliance.yml
@@ -9,6 +9,14 @@ trigger:
   paths:
     exclude:
     - README.md
+    
+schedules:
+- cron: "0 18 * * Mon"
+  displayName: Monday 11am PDT (6pm UTC) build
+  branches:
+    include:
+    - master
+  always: true   
 
 pr: none
 

--- a/.vsts-compliance.yml
+++ b/.vsts-compliance.yml
@@ -15,7 +15,7 @@ schedules:
   displayName: Monday 11am PDT (6pm UTC) build
   branches:
     include:
-    - master
+    - main
   always: true   
 
 pr: none


### PR DESCRIPTION
vswhere is a mature codebase with little churn, which means compliance checks triggered by new code can be few and far between. Components can fall out of compliance in the meantime and not trigger a notification.