### PR TITLE
Prepare vswhere and vswhere.lib to be Vulcan ready

### DIFF
--- a/src/vswhere.lib/vswhere.lib.vcxproj
+++ b/src/vswhere.lib/vswhere.lib.vcxproj
@@ -61,6 +61,7 @@
       <SDLCheck>true</SDLCheck>
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/Zi %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/vswhere/vswhere.vcxproj
+++ b/src/vswhere/vswhere.vcxproj
@@ -65,10 +65,12 @@
       <SDLCheck>true</SDLCheck>
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/Zi %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalOptions>/profile %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>vswhere.exe.manifest</AdditionalManifestFiles>


### PR DESCRIPTION

We have received multiple APISCan violations on Azure DevOps, and one of the files that were flagged was vswhere.exe.
In order to fix the improperfileformat issues, we need to make sure to create Vulcan ready files.

For C/C++ and Managed C++ Modules, we should perform a couple of actions in order to make files Vulcan-ready:
1. We need to pass the /Zi flag for all native modules (except DLLs that only contain resources) when compiling to produce a separate PDB file that contains all the symbolic debugging information for use with the debugger.
  - https://learn.microsoft.com/en-us/cpp/build/reference/z7-zi-zi-debug-information-format?view=msvc-170
2. We need to pass the /profile flag to produce an output file when linking that can be used with the Performance Tools profiler.
  - https://learn.microsoft.com/en-us/cpp/build/reference/profile-performance-tools-profiler?view=msvc-170

The PR addresses the two actions and adds the appropriate compiler and linker flags.