### PR TITLE
Install .NET 6 before installing NBGV

### DIFF
--- a/inc/build.yml
+++ b/inc/build.yml
@@ -8,6 +8,12 @@ parameters:
   Sign: false
 
 steps:
+- task: UseDotNet@2
+  displayName: "Install .NET SDK"
+  inputs:
+    packageType: sdk
+    version: 6.x
+
 - powershell: |
     dotnet tool install --tool-path "${env:AGENT_TOOLSDIRECTORY}\nbgv" nbgv
     $version = & "${env:AGENT_TOOLSDIRECTORY}\nbgv\nbgv.exe" get-version --variable SemVer1


### PR DESCRIPTION
Install .NET 6 before installing NBGV. The latest NBGV tool requires .NET 6. Rather than locking to an older version of NBGV, we can lock to the .NET 6 LTS SDK.

This should unblock the internal CI builds.