### PR TITLE
Updated a spelling mistake in user facing text.

### DIFF
--- a/src/vswhere.lib/InstanceSelector.cpp
+++ b/src/vswhere.lib/InstanceSelector.cpp
@@ -66,7 +66,7 @@ bool InstanceSelector::Less(const ISetupInstancePtr& a, const ISetupInstancePtr&
         else
         {
             // If ISetupHelper is not available we have only legacy products, or very early pre-releases of VS2017.
-            // For version 10.0 and newer either should lexigraphically sort correctly.
+            // For version 10.0 and newer either should lexicographically sort correctly.
             return less(wstring(bstrVersionA), wstring(bstrVersionB));
         }
     }

--- a/src/vswhere.lib/vswhere.lib.rc
+++ b/src/vswhere.lib/vswhere.lib.rc
@@ -91,7 +91,7 @@ BEGIN
 \n                 See https://aka.ms/vswhere/versions for more information about versions.\
 \n  -latest        Return only the newest version and last installed.\
 \n  -sort          Sorts the instances from newest version and last installed to oldest.\
-\n                 When used with ""find"", first instances are sorted then files are sorted lexigraphically.\
+\n                 When used with ""find"", first instances are sorted then files are sorted lexicographically.\
 \n  -legacy        Also searches Visual Studio 2015 and older products. Information is limited.\
 \n                 This option cannot be used with either -products or -requires.\
 \n  -path          Gets the instance for the current path. Not compatible with any other selection option.\


### PR DESCRIPTION
The spelling of `lexicographically` was incorrectly entered as `lexigraphically`. Made the minor adjustment rebuilt the project and ran the tests with no issue.