### PR TITLE
Convert CI pipeline to MicroBuild template

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -15,33 +15,46 @@ trigger:
 
 pr: none
 
-queue:
-  name: VSEngSS-MicroBuild2019-1ES
-  timeoutInMinutes: 120
-  demands: 
-  - ChocolateyInstall
-  - MSBuild
-  - VisualStudio
-  - VSTest
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
 
-steps:
-- task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@2
-  displayName: Install signing plugin
-  inputs:
-    signType: $(SignType)
-    esrpSigning: true
-
-- template: inc/build.yml
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
-      BuildConfiguration: $(BuildConfiguration)
-      BuildPlatform: $(BuildPlatform)
-      Sign: true
+    pool:
+      name: VSEngSS-MicroBuild2022-1ES
+    sdl:
+      sourceAnalysisPool:
+        name: AzurePipelines-EO
+        image: AzurePipelinesWindows2022compliantGPT
+      policheck:
+        enabled: true
+      binskim:
+        enabled: true
+        scanOutputDirectoryOnly: true # BinSkim scans whole source tree but we only need to scan the output dir.
 
-- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-  displayName: Detect components
-  inputs:
-    sourceScanPath: $(Build.SourcesDirectory)
+    stages:
+      - stage: Build
+        jobs:
+          - job: Build
+            templateContext:
+              mb:
+                signing:
+                  enabled: true
+                  signType: $(SignType)
 
-- task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
-  displayName: Clean up
-  condition: succeededOrFailed()
+            steps:
+            - template: /pipelines/templates/build.yml@self
+              parameters:
+                  BuildConfiguration: $(BuildConfiguration)
+                  BuildPlatform: $(BuildPlatform)
+                  Sign: true
+                  PublishArtifactTemplate: /pipelines/templates/1es-publish-task.yml@self
+
+            - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
+              displayName: Clean up
+              condition: succeededOrFailed()

--- a/.vsts-compliance.yml
+++ b/.vsts-compliance.yml
@@ -21,7 +21,7 @@ schedules:
 pr: none
 
 queue:
-  name: VSEngSS-MicroBuild2019-1ES
+  name: VSEngSS-MicroBuild2022-1ES
   timeoutInMinutes: 120
   demands: 
   - ChocolateyInstall
@@ -30,11 +30,12 @@ queue:
   - VSTest
 
 steps:
-- template: inc/build.yml
+- template: /pipelines/templates/build.yml@self
   parameters:
-      BuildConfiguration: $(BuildConfiguration)
-      BuildPlatform: $(BuildPlatform)
-      Sign: false
+    BuildConfiguration: $(BuildConfiguration)
+    BuildPlatform: $(BuildPlatform)
+    Sign: false
+    PublishArtifactTemplate: /pipelines/templates/ado-publish-task.yml@self
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: Detect components

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,15 +12,16 @@ pr:
     - README.md
 
 pool:
-  vmImage: windows-2019
+  vmImage: windows-2022
 
 variables:
   BuildConfiguration: Release
   BuildPlatform: x86
 
 steps:
-- template: inc/build.yml
+- template: /pipelines/templates/build.yml@self
   parameters:
-      BuildConfiguration: $(BuildConfiguration)
-      BuildPlatform: $(BuildPlatform)
-      Docker: true
+    BuildConfiguration: $(BuildConfiguration)
+    BuildPlatform: $(BuildPlatform)
+    Docker: true
+    PublishArtifactTemplate: /pipelines/templates/ado-publish-task.yml@self

--- a/docker/Debug.dockerfile
+++ b/docker/Debug.dockerfile
@@ -4,7 +4,7 @@
 # Licensed under the MIT license. See LICENSE.txt in the project root for license information.
 
 # Based on latest image cached by Azure Pipelines: https://docs.microsoft.com/azure/devops/pipelines/agents/hosted#software
-FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
+FROM mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2022
 SHELL ["powershell.exe", "-ExecutionPolicy", "Bypass", "-Command"]
 
 ENV INSTALLER_VERSION=1.14.190.31519 `

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@
 # Licensed under the MIT license. See LICENSE.txt in the project root for license information.
 
 # Based on latest image cached by Azure Pipelines: https://docs.microsoft.com/azure/devops/pipelines/agents/hosted#software
-FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
+FROM mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2022
 SHELL ["powershell.exe", "-ExecutionPolicy", "Bypass", "-Command"]
 
 ENV INSTALLER_VERSION=1.14.190.31519 `

--- a/inc/Common.Debug.props
+++ b/inc/Common.Debug.props
@@ -10,7 +10,8 @@
       <LanguageStandard>stdcpp14</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <AdditionalOptions>/Zi /ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>shell32.lib</AdditionalDependencies>

--- a/inc/Common.Debug.props
+++ b/inc/Common.Debug.props
@@ -9,6 +9,8 @@
     <ClCompile>
       <LanguageStandard>stdcpp14</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <AdditionalOptions>/Zi /ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>shell32.lib</AdditionalDependencies>

--- a/inc/Common.props
+++ b/inc/Common.props
@@ -10,7 +10,8 @@
       <LanguageStandard>stdcpp14</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <AdditionalOptions>/Zi /ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>shell32.lib</AdditionalDependencies>

--- a/inc/Common.props
+++ b/inc/Common.props
@@ -9,6 +9,8 @@
     <ClCompile>
       <LanguageStandard>stdcpp14</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <AdditionalOptions>/Zi /ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>shell32.lib</AdditionalDependencies>

--- a/pipelines/templates/1es-publish-task.yml
+++ b/pipelines/templates/1es-publish-task.yml
@@ -1,0 +1,22 @@
+parameters:
+  - name: path
+    type: string
+
+  - name: artifactName
+    type: string
+
+  - name: displayName
+    type: string
+    default: 'Publish artifact'
+
+  - name: condition
+    type: string
+    default: succeeded()
+
+steps:
+  - task: 1ES.PublishPipelineArtifact@1
+    displayName: ${{ parameters.displayName }}
+    condition: ${{ parameters.condition }}
+    inputs:
+      targetPath: ${{ parameters.path }}
+      artifactName: ${{ parameters.artifactName }}

--- a/pipelines/templates/ado-publish-task.yml
+++ b/pipelines/templates/ado-publish-task.yml
@@ -1,0 +1,22 @@
+parameters:
+  - name: path
+    type: string
+  
+  - name: artifactName
+    type: string
+
+  - name: displayName
+    type: string
+    default: 'Publish artifact'
+
+  - name: condition
+    type: string
+    default: succeeded()
+
+steps:
+  - task: PublishBuildArtifacts@1
+    displayName: ${{ parameters.displayName }}
+    condition: ${{ parameters.condition }}
+    inputs:
+      PathtoPublish: ${{ parameters.path }}
+      ArtifactName: ${{ parameters.artifactName }}

--- a/pipelines/templates/build.yml
+++ b/pipelines/templates/build.yml
@@ -6,6 +6,7 @@ parameters:
   BuildPlatform: x86
   Docker: false
   Sign: false
+  PublishArtifactTemplate: /pipelines/template/1es-publish-task.yml@self
 
 steps:
 - task: UseDotNet@2
@@ -102,9 +103,8 @@ steps:
      bin\${{ parameters.BuildConfiguration }}\**
     TargetFolder: $(Build.ArtifactStagingDirectory)\out
 
-- task: PublishBuildArtifacts@1
-  displayName: Publish build artifacts
-  inputs:
-    PathtoPublish: $(Build.ArtifactStagingDirectory)\out
-    ArtifactName: drop
-    publishLocation: Container
+- template: ${{ parameters.PublishArtifactTemplate }}
+  parameters:
+    displayName: Publish build artifacts
+    path: $(Build.ArtifactStagingDirectory)\out
+    artifactName: drop

--- a/pipelines/templates/build.yml
+++ b/pipelines/templates/build.yml
@@ -23,8 +23,6 @@ steps:
 
 - task: NuGetToolInstaller@0
   displayName: Install nuget
-  inputs:
-    versionSpec: '4.1.0'
 
 - task: NuGetCommand@2
   displayName: Restore packages

--- a/src/vswhere.lib/vswhere.lib.vcxproj
+++ b/src/vswhere.lib/vswhere.lib.vcxproj
@@ -59,9 +59,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalOptions>/Zi %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -86,8 +84,6 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
-      <AdditionalOptions>/Zi %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/vswhere.lib/vswhere.lib.vcxproj
+++ b/src/vswhere.lib/vswhere.lib.vcxproj
@@ -59,7 +59,6 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/vswhere/vswhere.vcxproj
+++ b/src/vswhere/vswhere.vcxproj
@@ -63,9 +63,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalOptions>/Zi %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -86,8 +84,6 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
-      <AdditionalOptions>/Zi %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/vswhere/vswhere.vcxproj
+++ b/src/vswhere/vswhere.vcxproj
@@ -63,7 +63,6 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/test/vswhere.test/vswhere.test.vcxproj
+++ b/test/vswhere.test/vswhere.test.vcxproj
@@ -71,6 +71,7 @@
       </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
+      <AdditionalOptions>/DYNAMICBASE %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -97,6 +98,7 @@
       </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
+      <AdditionalOptions>/DYNAMICBASE %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
To remain compliant, all production pipelines must be converted to the 1ES pipeline template. The MicroBuild template is an extension on that template that simplifies installation of MicroBuild plugins.

While doing this work, I updated to the 2022 VS pool. This required an additional update to the Dockerfile to use a 2022 image.