### PR TITLE
Update compliance pipeline to run all tools and log bugs

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,9 @@
+{
+    "codebaseName": "VSWhere",
+    "instanceUrl": "https://devdiv.visualstudio.com/defaultcollection",
+    "projectName": "DevDiv",
+    "areaPath": "DevDiv\\VS Setup",
+    "iterationPath": "DevDiv",
+    "allTools": true
+  }
+  

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -36,6 +36,10 @@ extends:
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true # BinSkim scans whole source tree but we only need to scan the output dir.
+      tsa:
+        enabled: true
+        configFile: $(Build.SourcesDirectory)\.config\tsaoptions.json
+        onboard: false
 
     stages:
       - stage: Build

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -30,7 +30,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: AzurePipelines-EO
-        image: AzurePipelinesWindows2022compliantGPT
+        image: 1ESPT-Windows2022
       policheck:
         enabled: true
       binskim:
@@ -54,7 +54,3 @@ extends:
                   BuildPlatform: $(BuildPlatform)
                   Sign: true
                   PublishArtifactTemplate: /pipelines/templates/1es-publish-task.yml@self
-
-            - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
-              displayName: Clean up
-              condition: succeededOrFailed()

--- a/.vsts-compliance.yml
+++ b/.vsts-compliance.yml
@@ -20,67 +20,53 @@ schedules:
 
 pr: none
 
-queue:
-  name: VSEngSS-MicroBuild2022-1ES
-  timeoutInMinutes: 120
-  demands: 
-  - ChocolateyInstall
-  - MSBuild
-  - VisualStudio
-  - VSTest
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
 
-steps:
-- template: /pipelines/templates/build.yml@self
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
-    BuildConfiguration: $(BuildConfiguration)
-    BuildPlatform: $(BuildPlatform)
-    Sign: false
-    PublishArtifactTemplate: /pipelines/templates/ado-publish-task.yml@self
+    pool:
+      name: VSEngSS-MicroBuild2022-1ES
+    sdl:
+      sourceAnalysisPool:
+        name: AzurePipelines-EO
+        image: 1ESPT-Windows2022
+      antimalwareScan:
+        enabled: true
+      armory:
+        enabled: true
+      binskim:
+        enabled: true
+        scanOutputDirectoryOnly: true
+      codeql:
+        compiled:
+          enabled: true
+      credscan:
+        enabled: true
+      policheck:
+        enabled: true
+      psscriptanalyzer:
+        enabled: true
+      prefast:
+        enabled: true
+      tsa:
+        enabled: true
+        configFile: $(Build.SourcesDirectory)\.config\tsaoptions.json
 
-- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-  displayName: Detect components
-  inputs:
-    sourceScanPath: $(Build.SourcesDirectory)
-
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-prefast.SDLNativeRules@2
-  displayName: Run the PREfast SDL Native Rules for MSBuild
-  continueOnError: true
-
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
-  displayName: Run PoliCheck
-  inputs:
-    targetType: F
-    targetArgument: '$(Build.SourcesDirectory)'
-    optionsFC: 0
-    optionsXS: 1
-    optionsHMENABLE: 0
-  continueOnError: true
-
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
-  displayName: Run BinSkim
-  inputs:
-    InputType: Basic
-    Function: analyze
-    AnalyzeTarget: 'bin\$(BuildConfiguration)\*.exe'
-    AnalyzeSymPath: 'bin\$(BuildConfiguration)'
-    AnalyzeVerbose: true
-    AnalyzeHashes: true
-  continueOnError: true
-
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
-  displayName: Run CredScan
-  inputs:
-    debugMode: false
-
-# Publish compliance results
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
-  displayName: Publish Security Analysis Logs
-
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
-  displayName: Check SDL results
-  inputs:
-    AllTools: true
-
-- task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
-  displayName: Clean up
-  condition: succeededOrFailed()
+    stages:
+      - stage: Compliance
+        jobs:
+          - job: Compliance
+            templateContext:
+            steps:
+            - template: /pipelines/templates/build.yml@self
+              parameters:
+                  BuildConfiguration: $(BuildConfiguration)
+                  BuildPlatform: $(BuildPlatform)
+                  Sign: false
+                  PublishArtifactTemplate: /pipelines/templates/1es-publish-task.yml@self

--- a/.vsts-compliance.yml
+++ b/.vsts-compliance.yml
@@ -20,6 +20,10 @@ schedules:
 
 pr: none
 
+variables:
+  - group: vssetup-apiscan
+  - group: vssetup-apiscan-secrets
+
 resources:
   repositories:
   - repository: MicroBuildTemplate
@@ -57,16 +61,58 @@ extends:
       tsa:
         enabled: true
         configFile: $(Build.SourcesDirectory)\.config\tsaoptions.json
+        onboard: false
 
     stages:
       - stage: Compliance
         jobs:
           - job: Compliance
-            templateContext:
             steps:
-            - template: /pipelines/templates/build.yml@self
-              parameters:
-                  BuildConfiguration: $(BuildConfiguration)
-                  BuildPlatform: $(BuildPlatform)
-                  Sign: false
-                  PublishArtifactTemplate: /pipelines/templates/1es-publish-task.yml@self
+              - template: /pipelines/templates/build.yml@self
+                parameters:
+                    BuildConfiguration: $(BuildConfiguration)
+                    BuildPlatform: $(BuildPlatform)
+                    Sign: false
+                    PublishArtifactTemplate: /pipelines/templates/1es-publish-task.yml@self
+
+              - task: CopyFiles@2
+                displayName: Copy files for API scan
+                inputs:
+                  SourceFolder: $(Build.SourcesDirectory)\bin\$(BuildConfiguration)
+                  Contents: |
+                    **\*.?(exe|dll|pdb|xml)
+                  TargetFolder: $(Build.StagingDirectory)\apiscan-inputs
+
+              - task: APIScan@2
+                displayName: Run APIScan
+                inputs:
+                  softwareFolder: $(Build.StagingDirectory)\apiscan-inputs
+                  softwareName: 'Microsoft.VSWhere'
+                  softwareVersionNum: '3'
+                  toolVersion: Latest
+                env:
+                  AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(SetupAppApiScanSecret)
+
+              - task: PublishSecurityAnalysisLogs@3
+                displayName: Publish 'SDLAnalysis-APIScan' artifact
+                condition: succeededOrFailed()
+                inputs:
+                  ArtifactName: SDLAnalysis-APIScan
+                  AllTools: false
+                  APIScan: true
+
+              - task: PostAnalysis@2
+                displayName: Post Analysis
+                inputs:
+                  GdnBreakAllTools: false
+                  GdnBreakGdnToolApiScan: true
+                
+              - task: TSAUpload@2
+                displayName: Upload APIScan results to TSA
+                inputs:
+                  GdnPublishTsaOnboard: false
+                  GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\.config\tsaoptions.json'
+                  GdnPublishTsaExportedResultsPublishable: true
+                continueOnError: true
+                condition: succeededOrFailed()
+                enabled: true

--- a/.vsts-compliance.yml
+++ b/.vsts-compliance.yml
@@ -81,6 +81,7 @@ extends:
                   SourceFolder: $(Build.SourcesDirectory)\bin\$(BuildConfiguration)
                   Contents: |
                     **\*.?(exe|dll|pdb|xml)
+                    !**\*.test.?(exe|dll|pdb|xml)
                   TargetFolder: $(Build.StagingDirectory)\apiscan-inputs
 
               - task: APIScan@2


### PR DESCRIPTION
Update compliance pipeline to run all tools and log bugs. This includes APIScan which is needed for all of our shipping code.

Also, adds bug logging to our CI build for any compliance issues and moves the static analysis to the new, approved 1ES pool.

I verified the compliance pipeline runs all tools and that the CI build still works.