### PR TITLE
Enable source link and bump compiler and language standard version

### DIFF
--- a/pipelines/templates/build.yml
+++ b/pipelines/templates/build.yml
@@ -49,15 +49,16 @@ steps:
 
 - ${{ if eq(parameters.Docker, 'true') }}:
   # Make sure service images are rebuilt if Dockerfiles changed.
-  - task: DockerCompose@0
+  - task: DockerCompose@1
     displayName: Build images
     inputs:
       dockerComposeFile: docker/docker-compose.yml
       action: Build services
+      projectName: microsoft-vswhere
     env:
       CONFIGURATION: ${{ parameters.BuildConfiguration }}
 
-  - task: DockerCompose@0
+  - task: DockerCompose@1
     displayName: Runtime tests
     inputs:
       dockerComposeFile: docker/docker-compose.yml
@@ -65,6 +66,7 @@ steps:
       serviceName: test
       containerCommand: -Command Invoke-Pester C:\Tests -EnableExit -OutputFile C:\Tests\Results.xml -OutputFormat NUnitXml
       detached: false
+      projectName: microsoft-vswhere
     env:
       CONFIGURATION: ${{ parameters.BuildConfiguration }}
 

--- a/src/vswhere.lib/Glob.cpp
+++ b/src/vswhere.lib/Glob.cpp
@@ -6,7 +6,7 @@
 #include "stdafx.h"
 
 using namespace std;
-using namespace std::experimental::filesystem;
+using namespace std::filesystem;
 
 std::wstring rtrim(const std::wstring& value);
 

--- a/src/vswhere.lib/Glob.h
+++ b/src/vswhere.lib/Glob.h
@@ -32,7 +32,7 @@ private:
     static bool RequiresEscape(_In_ const wchar_t ch);
     static void ThrowError(_In_ const std::wstring& pattern);
 
-    std::experimental::filesystem::path m_root;
+    std::filesystem::path m_root;
     size_t m_root_length;
     std::wregex m_re;
 

--- a/src/vswhere.lib/Module.cpp
+++ b/src/vswhere.lib/Module.cpp
@@ -49,7 +49,7 @@ const wstring& Module::get_FileVersion() noexcept
         return m_fileVersion;
     }
 
-    vector<byte> buffer(cbVersionInfo);
+    vector<std::byte> buffer(cbVersionInfo);
     if (!::GetFileVersionInfoW(path.c_str(), 0, buffer.size(), buffer.data()))
     {
         return m_fileVersion;

--- a/src/vswhere.lib/Utilities.cpp
+++ b/src/vswhere.lib/Utilities.cpp
@@ -5,9 +5,10 @@
 
 #include "stdafx.h"
 
-std::string to_string(const std::wstring& value)
-{
-    static wstring_converter converter;
-
-    return converter.to_bytes(value);
+std::string to_string(const std::wstring& value) {
+    if (value.empty()) return std::string();
+    int size_needed = WideCharToMultiByte(CP_UTF8, 0, value.data(), (int)value.size(), NULL, 0, NULL, NULL);
+    std::string result(size_needed, 0);
+    WideCharToMultiByte(CP_UTF8, 0, value.data(), (int)value.size(), result.data(), size_needed, NULL, NULL);
+    return result;
 }

--- a/src/vswhere.lib/Utilities.h
+++ b/src/vswhere.lib/Utilities.h
@@ -5,11 +5,9 @@
 
 #pragma once
 
-typedef std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> wstring_converter;
-
 std::string to_string(const std::wstring& value);
 
-struct ci_equal : public std::binary_function<std::wstring, std::wstring, bool>
+struct ci_equal
 {
     bool operator()(const std::wstring& lhs, const std::wstring& rhs) const
     {
@@ -17,7 +15,7 @@ struct ci_equal : public std::binary_function<std::wstring, std::wstring, bool>
     }
 };
 
-struct ci_less : public std::binary_function<std::wstring, std::wstring, bool>
+struct ci_less
 {
     bool operator()(const std::wstring& lhs, const std::wstring& rhs) const
     {

--- a/src/vswhere.lib/vswhere.lib.vcxproj
+++ b/src/vswhere.lib/vswhere.lib.vcxproj
@@ -83,6 +83,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
     </ClCompile>
     <Link>

--- a/src/vswhere.lib/vswhere.lib.vcxproj
+++ b/src/vswhere.lib/vswhere.lib.vcxproj
@@ -28,7 +28,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/src/vswhere.lib/vswhere.lib.vcxproj
+++ b/src/vswhere.lib/vswhere.lib.vcxproj
@@ -22,7 +22,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -59,6 +59,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/vswhere/packages.config
+++ b/src/vswhere/packages.config
@@ -3,4 +3,7 @@
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.VisualStudio.Setup.Configuration.Native" version="1.11.2290" targetFramework="native" developmentDependency="true" />
   <package id="Nerdbank.GitVersioning" version="2.3.38" targetFramework="native" developmentDependency="true" />
+  <package id="Microsoft.Build.Tasks.Git" version="8.0.0" targetFramework="native" developmentDependency="true" />
+  <package id="Microsoft.SourceLink.Common" version="8.0.0" targetFramework="native" developmentDependency="true" />
+  <package id="Microsoft.SourceLink.GitHub" version="8.0.0" targetFramework="native" developmentDependency="true" />
 </packages>

--- a/src/vswhere/vswhere.vcxproj
+++ b/src/vswhere/vswhere.vcxproj
@@ -86,6 +86,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
     </ClCompile>
     <Link>

--- a/src/vswhere/vswhere.vcxproj
+++ b/src/vswhere/vswhere.vcxproj
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" Condition="Exists('..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" />
+  <Import Project="..\..\packages\Microsoft.Build.Tasks.Git.8.0.0\build\Microsoft.Build.Tasks.Git.props" Condition="Exists('..\..\packages\Microsoft.Build.Tasks.Git.8.0.0\build\Microsoft.Build.Tasks.Git.props')" />
+  <Import Project="..\..\packages\Microsoft.SourceLink.Common.8.0.0\build\Microsoft.SourceLink.Common.props" Condition="Exists('..\..\packages\Microsoft.SourceLink.Common.8.0.0\build\Microsoft.SourceLink.Common.props')" />
+  <Import Project="..\..\packages\Microsoft.SourceLink.GitHub.8.0.0\build\Microsoft.SourceLink.GitHub.props" Condition="Exists('..\..\packages\Microsoft.SourceLink.GitHub.8.0.0\build\Microsoft.SourceLink.GitHub.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -23,13 +26,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -63,6 +66,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,6 +135,9 @@
     <Import Project="..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" Condition="Exists('..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" />
     <Import Project="..\..\packages\Microsoft.VisualStudio.Setup.Configuration.Native.1.11.2290\build\native\Microsoft.VisualStudio.Setup.Configuration.Native.targets" Condition="Exists('..\..\packages\Microsoft.VisualStudio.Setup.Configuration.Native.1.11.2290\build\native\Microsoft.VisualStudio.Setup.Configuration.Native.targets')" />
     <Import Project="..\..\packages\Nerdbank.GitVersioning.2.3.38\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.2.3.38\build\Nerdbank.GitVersioning.targets')" />
+    <Import Project="..\..\packages\Microsoft.Build.Tasks.Git.8.0.0\build\Microsoft.Build.Tasks.Git.targets" Condition="Exists('..\..\packages\Microsoft.Build.Tasks.Git.8.0.0\build\Microsoft.Build.Tasks.Git.targets')" />
+    <Import Project="..\..\packages\Microsoft.SourceLink.Common.8.0.0\build\Microsoft.SourceLink.Common.targets" Condition="Exists('..\..\packages\Microsoft.SourceLink.Common.8.0.0\build\Microsoft.SourceLink.Common.targets')" />
+    <Import Project="..\..\packages\Microsoft.SourceLink.GitHub.8.0.0\build\Microsoft.SourceLink.GitHub.targets" Condition="Exists('..\..\packages\Microsoft.SourceLink.GitHub.8.0.0\build\Microsoft.SourceLink.GitHub.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/vswhere.test/ExceptionsTests.cpp
+++ b/test/vswhere.test/ExceptionsTests.cpp
@@ -28,7 +28,7 @@ public:
     {
         win32_error sut(ERROR_NOT_FOUND);
         Assert::AreEqual<int>(ERROR_NOT_FOUND, sut.code().value());
-        Assert::AreEqual("Element not found.\r\n", sut.what());
+        Assert::AreEqual("Element not found.", sut.what());
         Assert::AreEqual(L"Element not found.\r\n", sut.wwhat());
     }
 
@@ -36,7 +36,7 @@ public:
     {
         win32_error sut(ERROR_NOT_FOUND, L"property not found");
         Assert::AreEqual<int>(ERROR_NOT_FOUND, sut.code().value());
-        Assert::AreEqual("property not found: Element not found.\r\n", sut.what());
+        Assert::AreEqual("property not found: Element not found.", sut.what());
         Assert::AreEqual(L"property not found", sut.wwhat());
     }
 };

--- a/test/vswhere.test/TestInstance.h
+++ b/test/vswhere.test/TestInstance.h
@@ -174,7 +174,7 @@ public:
         auto hr = GetInstallationPath(bstrPath.GetAddress());
         if (SUCCEEDED(hr))
         {
-            std::experimental::filesystem::v1::path absolutePath((LPWSTR)bstrPath);
+            std::filesystem::path absolutePath((LPWSTR)bstrPath);
 
             hr = GetProductPath(bstrPath.GetAddress());
             if (SUCCEEDED(hr))

--- a/test/vswhere.test/vswhere.test.vcxproj
+++ b/test/vswhere.test/vswhere.test.vcxproj
@@ -24,7 +24,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
@@ -72,6 +72,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <AdditionalOptions>/DYNAMICBASE %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/test/vswhere.test/vswhere.test.vcxproj
+++ b/test/vswhere.test/vswhere.test.vcxproj
@@ -31,7 +31,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>

--- a/test/vswhere.test/vswhere.test.vcxproj
+++ b/test/vswhere.test/vswhere.test.vcxproj
@@ -100,6 +100,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <AdditionalOptions>/DYNAMICBASE %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
## What?
Enable source link and bump compiler version to v143 and language standard version to C++ 17 (to resolve source link path capital letters). Also deleted usage of deprecated functions or replaced the function.

## Why?
Allow debugger to download underlying source files if needed

## How?
Add source link package reference to config and vcxproj file

## Testing?
- [x] Ran end-to-end testing and ensured the file was downloaded from sourcelink while debugging
![Screenshot 2024-12-10 141008](https://github.com/user-attachments/assets/800eabe2-b9c7-4eb4-a675-3433872029aa)
