### PR TITLE
Bump .net sdk version

### DIFF
--- a/pipelines/templates/build.yml
+++ b/pipelines/templates/build.yml
@@ -13,7 +13,7 @@ steps:
   displayName: "Install .NET SDK"
   inputs:
     packageType: sdk
-    version: 6.x
+    version: 8.x
 
 - powershell: |
     dotnet tool install --tool-path "${env:AGENT_TOOLSDIRECTORY}\nbgv" nbgv


### PR DESCRIPTION
## What
Bump .net sdk version

## Why
nbgv is not compatiable with .net 6.0, causing ci pipeline failure

## How
Bump .net sdk version in yaml

## Test
[x] Ran test pipeline on this change