### PR TITLE
Add glob pattern for binskim task

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -36,6 +36,7 @@ extends:
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true # BinSkim scans whole source tree but we only need to scan the output dir.
+        analyzeTargetGlob: +:f|$(Build.ArtifactStagingDirectory)\out\**;-:f|$(Build.ArtifactStagingDirectory)\out\**\*.test.*
       tsa:
         enabled: true
         configFile: $(Build.SourcesDirectory)\.config\tsaoptions.json

--- a/.vsts-compliance.yml
+++ b/.vsts-compliance.yml
@@ -29,9 +29,6 @@ resources:
     type: git
     name: 1ESPipelineTemplates/MicroBuildTemplate
     ref: refs/tags/release
-  pipelines:
-  - pipeline: Vswhere-CI # identifier for the resource (used in pipeline resource variables)
-    source: Setup-vswhere-CI # name of the pipeline that produces an artifact
 
 extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
@@ -49,6 +46,7 @@ extends:
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true
+        analyzeTargetGlob: +:f|$(Build.ArtifactStagingDirectory)\out\**;-:f|$(Build.ArtifactStagingDirectory)\out\**\*.test.*
       codeql:
         compiled:
           enabled: true
@@ -70,13 +68,17 @@ extends:
         jobs:
           - job: Compliance
             steps:
-              - download: Vswhere-CI
-                artifact: drop
+              - template: /pipelines/templates/build.yml@self
+                parameters:
+                    BuildConfiguration: $(BuildConfiguration)
+                    BuildPlatform: $(BuildPlatform)
+                    Sign: false
+                    PublishArtifactTemplate: /pipelines/templates/1es-publish-task.yml@self
 
               - task: CopyFiles@2
                 displayName: Copy files for API scan
                 inputs:
-                  SourceFolder: $(Pipeline.Workspace)\Vswhere-CI\drop
+                  SourceFolder: $(Build.SourcesDirectory)\bin\$(BuildConfiguration)
                   Contents: |
                     **\*.?(exe|dll|pdb|xml)
                     !**\*.test.?(exe|dll|pdb|xml)

--- a/.vsts-compliance.yml
+++ b/.vsts-compliance.yml
@@ -29,6 +29,9 @@ resources:
     type: git
     name: 1ESPipelineTemplates/MicroBuildTemplate
     ref: refs/tags/release
+  pipelines:
+  - pipeline: Vswhere-CI # identifier for the resource (used in pipeline resource variables)
+    source: Setup-vswhere-CI # name of the pipeline that produces an artifact
 
 extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
@@ -67,17 +70,13 @@ extends:
         jobs:
           - job: Compliance
             steps:
-              - template: /pipelines/templates/build.yml@self
-                parameters:
-                    BuildConfiguration: $(BuildConfiguration)
-                    BuildPlatform: $(BuildPlatform)
-                    Sign: false
-                    PublishArtifactTemplate: /pipelines/templates/1es-publish-task.yml@self
+              - download: Vswhere-CI
+                artifact: drop
 
               - task: CopyFiles@2
                 displayName: Copy files for API scan
                 inputs:
-                  SourceFolder: $(Build.SourcesDirectory)\bin\$(BuildConfiguration)
+                  SourceFolder: $(Pipeline.Workspace)\Vswhere-CI\drop
                   Contents: |
                     **\*.?(exe|dll|pdb|xml)
                     !**\*.test.?(exe|dll|pdb|xml)

--- a/pipelines/templates/build.yml
+++ b/pipelines/templates/build.yml
@@ -9,12 +9,6 @@ parameters:
   PublishArtifactTemplate: /pipelines/template/1es-publish-task.yml@self
 
 steps:
-- task: UseDotNet@2
-  displayName: "Install .NET SDK"
-  inputs:
-    packageType: sdk
-    version: 8.x
-
 - powershell: |
     dotnet tool install --tool-path "${env:AGENT_TOOLSDIRECTORY}\nbgv" nbgv
     $version = & "${env:AGENT_TOOLSDIRECTORY}\nbgv\nbgv.exe" get-version --variable SemVer1


### PR DESCRIPTION
## What
This PR includes two changes updating various yaml files
1. Exclude test artifacts from binskim
2. Delete installing specific .net sdk version, we can use what's on the pool

## Why
1. The test artifacts are being flagged to enable source link, which isn't necessary.
2. No need to install specific version, use what's on the pool

## How
Include glob pattern for which files to scan for binskim and delete installing .net sdk task

## Testing
Manually ran ci pipeline and checked that vswhere.test.dll isn't being scanned unlike previously. Compliance pipeline also successfully ran.