### PR TITLE
disable 26444 warning for prefast

### DIFF
--- a/test/vswhere.test/GlobTests.cpp
+++ b/test/vswhere.test/GlobTests.cpp
@@ -147,7 +147,10 @@ public:
     {
         try
         {
+        #pragma warning(push)
+        #pragma warning(disable:26444) // Ignore warning C26444: Don't try to declare a local variable with no name since it is intended for below lambda
             Glob(L"C:\\ShouldNotExist", L"**msbuild.exe");
+        #pragma warning(pop)
         }
         catch (const win32_error& ex)
         {

--- a/test/vswhere.test/InstanceSelectorTests.cpp
+++ b/test/vswhere.test/InstanceSelectorTests.cpp
@@ -248,8 +248,10 @@ public:
         args.Parse(L"vswhere.exe -version invalid");
 
         TestHelper helper(0, 0);
-
+    #pragma warning(push)
+    #pragma warning(disable:26444) // Ignore warning C26444: Don't try to declare a local variable with no name since it is intended for below lambda 
         Assert::ExpectException<win32_error>([&] { InstanceSelector(args, &helper); });
+    #pragma warning(pop)
     }
 
     TEST_METHOD(Less_No_Version_A)


### PR DESCRIPTION
## What
Disable [C26444: Don't try to declare a local variable with no name warning ](https://learn.microsoft.com/en-us/cpp/code-quality/c26444?view=msvc-170)

## Why
Prefast is flagging C26444 warning on lambda that was used in test file. However, the lambda is used as intended. Therefore disable C26444 for those cases.

## How
Declare pragma disable around the line prefast is flagging.

## Testing
Ensured unit test runs properaly