### PR TITLE
Add noexcept to the ResourceManager move constructor

### DIFF
--- a/src/vswhere.lib/ResourceManager.h
+++ b/src/vswhere.lib/ResourceManager.h
@@ -28,7 +28,7 @@ public:
 private:
     ResourceManager() {}
     ResourceManager(const ResourceManager& obj) {}
-    ResourceManager(ResourceManager&& obj) {}
+    ResourceManager(ResourceManager&& obj) noexcept {}
 
     static std::wstring FormatString(_In_ DWORD nID, _In_ va_list args);
 


### PR DESCRIPTION
## What
Fix prefast warning 26439: This kind of function may not throw. Declare it 'noexcept'.

## Why
Stay compliant with the C++ Core Guidelines and improve code safety by declaring the move constructor as noexcept.
 
## How
Add noexcept to the ResourceManager move constructor.

## Testing
Ensured unit test runs properly.