### PR TITLE
Reinsert missing IDS_E_PATHINCOMPATIBLE string

### DIFF
--- a/src/vswhere.lib/vswhere.lib.rc
+++ b/src/vswhere.lib/vswhere.lib.rc
@@ -64,6 +64,7 @@ BEGIN
     IDS_E_ARGINCOMPAT       "The ""%1$ls"" parameter cannot be specified with the ""%2$ls"" parameter"
     IDS_E_INVALIDPATTERN    "The pattern ""%1$ls"" is invalid"
     IDS_E_UNSUPPORTEDARG    "Unsupported argument ""%1$ls"" for parameter ""%2$ls"""
+    IDS_E_PATHINCOMPATIBLE  "The ""path"" parameter cannot be specified with other selection parameters"
 END
 
 STRINGTABLE


### PR DESCRIPTION
The error IDS_E_PATHINCOMPATIBLE  was accidentally removed in #201 , which leads to a `Error 0x7f: The specified procedure could not be found.` output when specifying the `-path` arg with any other argument.

This PR restores the missing string (used [here](https://github.com/microsoft/vswhere/blob/main/src/vswhere.lib/CommandArgs.cpp#L216)).