### PR TITLE
 Enable PME signing for vswhere and allow only real sign for the CI pipeline

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,6 +1,9 @@
 # Copyright (C) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt in the project root for license information.
 
+variables:
+  SignType: Real
+
 trigger:
   batch: true
   branches:
@@ -51,6 +54,7 @@ extends:
                 signing:
                   enabled: true
                   signType: $(SignType)
+                  signWithProd: true
 
             steps:
             - template: /pipelines/templates/build.yml@self


### PR DESCRIPTION
## What/Why
We need to enable PME signing with the new rule enforcement (Real signing with PME Enforcement - June 30th 2025).

## How
1. Enable PME signing with `signWithProd: true`
2. Only allow real signs for the CI pipeline.

## Testing
Verified the stages can be configured in the topic branch (which indicates no errors in the pipeline).