### PR TITLE
Fix APIScan in the compliance pipeline

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -12,7 +12,7 @@
     "Microsoft.VisualStudio.Component.VC.DiagnosticTools",
     "Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
     "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core",
-    "Microsoft.VisualStudio.Component.Windows10SDK.19041",
+    "Microsoft.VisualStudio.Component.Windows11SDK.22621",
     "Microsoft.VisualStudio.Component.VC.v141.x86.x64",
     "Microsoft.VisualStudio.Workload.NativeDesktop",
     "Microsoft.VisualStudio.Component.Git",

--- a/.vsts-compliance.yml
+++ b/.vsts-compliance.yml
@@ -91,8 +91,10 @@ extends:
                   softwareName: 'Microsoft.VSWhere'
                   softwareVersionNum: '3'
                   toolVersion: Latest
+                  azureSubscription: VSEng-APIScanSC
                 env:
-                  AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId)
+                  AzureServicesAuthConnectionString: RunAs=App;AppId=$(ApiScanClientId);TenantId=72f988bf-86f1-41af-91ab-2d7cd011db47;ServiceConnectionId=93e24264-c5e6-4681-8175-ec8a41668480;
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
               - task: PublishSecurityAnalysisLogs@3
                 displayName: Publish 'SDLAnalysis-APIScan' artifact

--- a/src/vswhere.lib/vswhere.lib.vcxproj
+++ b/src/vswhere.lib/vswhere.lib.vcxproj
@@ -15,8 +15,8 @@
     <ProjectGuid>{4CCF39CB-4794-44E2-AA57-D215F13CF606}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>vswherelib</RootNamespace>
-    <TargetUniversalCRTVersion>10.0.19041.0</TargetUniversalCRTVersion>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <TargetUniversalCRTVersion>10.0.22621.0</TargetUniversalCRTVersion>
+    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/vswhere/vswhere.vcxproj
+++ b/src/vswhere/vswhere.vcxproj
@@ -19,8 +19,8 @@
     <ProjectGuid>{210864F0-9A29-4479-B830-B802EE3F4D92}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>vswhere</RootNamespace>
-    <TargetUniversalCRTVersion>10.0.19041.0</TargetUniversalCRTVersion>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <TargetUniversalCRTVersion>10.0.22621.0</TargetUniversalCRTVersion>
+    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/test/vswhere.test/vswhere.test.vcxproj
+++ b/test/vswhere.test/vswhere.test.vcxproj
@@ -16,8 +16,8 @@
     <ProjectGuid>{76268871-D5A5-46BD-9805-41DB1C3072D1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>vswheretest</RootNamespace>
-    <TargetUniversalCRTVersion>10.0.19041.0</TargetUniversalCRTVersion>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <TargetUniversalCRTVersion>10.0.22621.0</TargetUniversalCRTVersion>
+    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />


### PR DESCRIPTION
## What?
Update the APIScan authentication configuration in the compliance pipeline to match the current auth pattern.

## Why?
The compliance pipeline was failing at the APIScan step because the old auth format (runAs=App;AppId=...) no longer works. The managed identity credential could not be acquired, resulting in "Identity not found" errors.
Also, the SDK we've been using is no longer supported.

## How?
Updated vsts-compliance.yml to align with the working Setup-Engine-Compliance pipeline:

   - Added azureSubscription: VSEng-APIScanSC service connection input
   - Extended AzureServicesAuthConnectionString with TenantId and ServiceConnectionId
   - Added SYSTEM_ACCESSTOKEN: $(System.AccessToken) environment variable

Also, updated the SDK version to the one that is supported by the pool we use.

## Testing?
- [x] Verified the compliance pipeline passes at the APIScan step

## Screenshots (optional)
<img width="326" height="419" alt="image" src="https://github.com/user-attachments/assets/38887aea-fdc4-4a23-8cab-89dfe6f78ce8" />

