### PR TITLE
Restore packages from internal feed to prevent nuget.org access

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -28,6 +28,8 @@ resources:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2
     pool:
       name: VSEngSS-MicroBuild2022-1ES
     sdl:

--- a/.vsts-compliance.yml
+++ b/.vsts-compliance.yml
@@ -33,6 +33,8 @@ resources:
 extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2
     pool:
       name: VSEngSS-MicroBuild2022-1ES
     sdl:

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="Setup-Dependencies" value="https://devdiv.pkgs.visualstudio.com/_packaging/Setup-Dependencies/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="Setup-Dependencies" value="https://devdiv.pkgs.visualstudio.com/_packaging/Setup-Dependencies/nuget/v3/index.json" />
+    <add key="Setup-Dependencies" value="https://pkgs.dev.azure.com/azure-public/vssetup/_packaging/Setup-Dependencies/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/pipelines/templates/build.yml
+++ b/pipelines/templates/build.yml
@@ -9,17 +9,25 @@ parameters:
   PublishArtifactTemplate: /pipelines/template/1es-publish-task.yml@self
 
 steps:
+- task: NuGetToolInstaller@0
+  displayName: Install nuget
+
+- task: NuGetAuthenticate@1
+  displayName: Authenticate to Azure Artifacts
+
 - powershell: |
-    dotnet tool install --tool-path "${env:AGENT_TOOLSDIRECTORY}\nbgv" nbgv
+    dotnet tool install --tool-path "${env:AGENT_TOOLSDIRECTORY}\nbgv" nbgv --configfile "$(Build.SourcesDirectory)\nuget.config"
     $version = & "${env:AGENT_TOOLSDIRECTORY}\nbgv\nbgv.exe" get-version --variable SemVer1
     & "${env:AGENT_TOOLSDIRECTORY}\nbgv\nbgv.exe" cloud --version $version
   displayName: Set cloud build version
 
-- task: NuGetToolInstaller@0
-  displayName: Install nuget
-
 - task: NuGetCommand@2
   displayName: Restore packages
+  inputs:
+    command: restore
+    restoreSolution: vswhere.sln
+    feedsToUse: config
+    nugetConfigPath: $(Build.SourcesDirectory)\nuget.config
 
 - task: VSBuild@1
   displayName: Build


### PR DESCRIPTION
## Why
Builds were resolving NuGet packages directly from nuget.org, which is a build/security violation under the 1ES Secure Future Initiative (SFI) NuGet guidance. Package acquisition during the build must go through an approved internal Azure Artifacts feed, not the public gallery.

## What changed

- **New `nuget.config` at the repo root** that:
  - `<clear />`s all inherited package sources so nuget.org is never used directly.
  - Points only at the internal **Setup-Dependencies** Azure Artifacts feed (which proxies nuget.org via upstream).

- **`pipelines/templates/build.yml`**:
  - Added `NuGetAuthenticate@1` and moved it ahead of the version step so the internal feed is authenticated before any package pull.
  - Routed the `nbgv` dotnet tool install through the config via `--configfile`, since that was another implicit nuget.org access point.
  - Updated the `NuGetCommand@2` restore to use `feedsToUse: config` with `nugetConfigPath` pointing at the checked-in `nuget.config`.